### PR TITLE
feat(oauth): PKCE + authorization URL + token exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,39 @@ Task {
 }
 ```
 
+## OAuth / PKCE
+
+```swift
+import LichessClient
+
+let pkce = LichessClient.generatePKCE()
+let state = UUID().uuidString
+let redirect = URL(string: "myapp://callback")!
+
+// 1) Send user to this URL (open in browser / webview)
+let authURL = LichessClient().buildAuthorizationURL(
+  clientID: "myapp",
+  redirectURI: redirect,
+  scopes: ["challenge:write", "email:read"],
+  state: state,
+  pkce: pkce
+)
+
+// 2) Handle redirect back to your app and extract the `code`
+// let code = ...
+
+// 3) Exchange code for token
+let token = try await LichessClient().exchangeCodeForToken(
+  clientID: "myapp",
+  code: code,
+  redirectURI: redirect,
+  codeVerifier: pkce.codeVerifier
+)
+
+// 4) Create an authenticated client
+let authed = LichessClient(accessToken: token.accessToken)
+```
+
 ## Configuration, Transport, and Auth
 
 ```swift

--- a/Sources/LichessClient/LichessClient+OAuth.swift
+++ b/Sources/LichessClient/LichessClient+OAuth.swift
@@ -1,0 +1,136 @@
+import Foundation
+import CryptoKit
+import OpenAPIRuntime
+
+extension LichessClient {
+  public struct PKCE: Sendable, Hashable {
+    public let codeVerifier: String
+    public let codeChallenge: String
+  }
+
+  public struct OAuthToken: Sendable, Hashable {
+    public let tokenType: String
+    public let accessToken: String
+    public let expiresIn: Int
+    public let expiresAt: Date
+  }
+
+  public static func generatePKCE(verifierLength: Int = 64) -> PKCE {
+    let length = max(43, min(verifierLength, 128))
+    var bytes = [UInt8](repeating: 0, count: length)
+    for i in 0..<length { bytes[i] = UInt8.random(in: 0...255) }
+    let verifier = base64urlNoPadding(Data(bytes))
+    let challenge = s256Challenge(for: verifier)
+    return PKCE(codeVerifier: verifier, codeChallenge: challenge)
+  }
+
+  public static func s256Challenge(for codeVerifier: String) -> String {
+    let digest = SHA256.hash(data: Data(codeVerifier.utf8))
+    return base64urlNoPadding(Data(digest))
+  }
+
+  static func base64urlNoPadding(_ data: Data) -> String {
+    let base = data.base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+    return base
+  }
+
+  public func buildAuthorizationURL(
+    clientID: String,
+    redirectURI: URL,
+    scopes: [String],
+    state: String,
+    username: String? = nil,
+    pkce: PKCE
+  ) -> URL {
+    var components = URLComponents(url: URL(string: "https://lichess.org/oauth")!, resolvingAgainstBaseURL: false)!
+    let items: [URLQueryItem?] = [
+      URLQueryItem(name: "response_type", value: "code"),
+      URLQueryItem(name: "client_id", value: clientID),
+      URLQueryItem(name: "redirect_uri", value: redirectURI.absoluteString),
+      URLQueryItem(name: "code_challenge_method", value: "S256"),
+      URLQueryItem(name: "code_challenge", value: pkce.codeChallenge),
+      URLQueryItem(name: "scope", value: scopes.joined(separator: " ")),
+      URLQueryItem(name: "state", value: state),
+      username.map { URLQueryItem(name: "username", value: $0) }
+    ]
+    components.queryItems = items.compactMap { $0 }
+    return components.url!
+  }
+
+  public func exchangeCodeForToken(
+    clientID: String,
+    code: String,
+    redirectURI: URL,
+    codeVerifier: String
+  ) async throws -> OAuthToken {
+    let body: Operations.apiToken.Input.Body = .urlEncodedForm(.init(
+      grant_type: .authorization_code,
+      code: code,
+      code_verifier: codeVerifier,
+      redirect_uri: redirectURI.absoluteString,
+      client_id: clientID
+    ))
+    let response = try await underlyingClient.apiToken(body: body)
+    switch response {
+    case .ok(let ok):
+      let payload = try ok.body.json
+      return OAuthToken(
+        tokenType: payload.token_type,
+        accessToken: payload.access_token,
+        expiresIn: payload.expires_in,
+        expiresAt: Date().addingTimeInterval(TimeInterval(payload.expires_in))
+      )
+    case .badRequest(let bad):
+      throw LichessClientError.parsingError(error: NSError(domain: "LichessOAuth", code: 400, userInfo: ["error": String(describing: bad)]))
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  public func revokeAccessToken() async throws {
+    let response = try await underlyingClient.apiTokenDelete()
+    switch response {
+    case .noContent:
+      return
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  public struct TokenTestResult: Sendable, Hashable {
+    public let userId: String?
+    public let scopes: [String]
+    public let expiresAt: Date?
+  }
+
+  public func testTokens(_ tokens: [String]) async throws -> [String: TokenTestResult?] {
+    let input = tokens.joined(separator: "\n")
+    let response = try await underlyingClient.tokenTest(
+      body: .plainText(.init(input))
+    )
+    switch response {
+    case .ok(let ok):
+      let dict = try ok.body.json.additionalProperties
+      var results: [String: TokenTestResult?] = [:]
+      for (token, value) in dict {
+        switch value {
+        case .case1(let info):
+          let scopes = (info.scopes ?? "").split(separator: ",").map { String($0) }.filter { !$0.isEmpty }
+          let expiresAt: Date?
+          if let ms = info.expires { expiresAt = Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0) } else { expiresAt = nil }
+          results[token] = .some(.init(userId: info.userId, scopes: scopes, expiresAt: expiresAt))
+        case .case2:
+          results[token] = nil
+        case .none:
+          results[token] = nil
+        }
+      }
+      return results
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/OAuthTests.swift
+++ b/Tests/LichessClientTests/OAuthTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+struct ClosureTransport: ClientTransport {
+  let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+  func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+    try await handler(request, body, baseURL, operationID)
+  }
+}
+
+final class OAuthTests: XCTestCase {
+
+  func testS256Vector() {
+    // RFC 7636 example vector
+    let verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+    let expected = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+    XCTAssertEqual(LichessClient.s256Challenge(for: verifier), expected)
+  }
+
+  func testAuthorizationURLBuilds() {
+    let pkce = LichessClient.PKCE(codeVerifier: "v", codeChallenge: "c")
+    let url = LichessClient().buildAuthorizationURL(
+      clientID: "myapp",
+      redirectURI: URL(string: "myapp://callback")!,
+      scopes: ["challenge:write", "email:read"],
+      state: "xyz",
+      username: "user",
+      pkce: pkce
+    )
+    let comps = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+    XCTAssertEqual(comps.path, "/oauth")
+    let q = Dictionary(uniqueKeysWithValues: comps.queryItems!.map { ($0.name, $0.value ?? "") })
+    XCTAssertEqual(q["code_challenge_method"], "S256")
+    XCTAssertEqual(q["code_challenge"], "c")
+    XCTAssertEqual(q["client_id"], "myapp")
+    XCTAssertEqual(q["redirect_uri"], "myapp://callback")
+    XCTAssertEqual(q["state"], "xyz")
+    XCTAssertEqual(q["username"], "user")
+    XCTAssertEqual(q["scope"], "challenge:write email:read")
+  }
+
+  func testExchangeUsesFormBody() async throws {
+    let transport = ClosureTransport { request, body, _, operationID in
+      XCTAssertEqual(operationID, "apiToken")
+      XCTAssertEqual(request.method, .post)
+      XCTAssertEqual(request.headerFields[.contentType], "application/x-www-form-urlencoded")
+      if let body = body {
+        let string = try await String(collecting: body, upTo: 4096)
+        XCTAssertTrue(string.contains("grant_type=authorization_code"))
+        XCTAssertTrue(string.contains("code=abc"))
+        XCTAssertTrue(string.contains("code_verifier=verif"))
+        XCTAssertTrue(string.contains("redirect_uri=myapp%3A%2F%2Fcb"))
+        XCTAssertTrue(string.contains("client_id=myapp"))
+      } else {
+        XCTFail("Missing body")
+      }
+      let json = "{\"token_type\":\"Bearer\",\"access_token\":\"tkn\",\"expires_in\":3600}"
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let token = try await client.exchangeCodeForToken(
+      clientID: "myapp",
+      code: "abc",
+      redirectURI: URL(string: "myapp://cb")!,
+      codeVerifier: "verif"
+    )
+    XCTAssertEqual(token.accessToken, "tkn")
+    XCTAssertEqual(token.tokenType, "Bearer")
+    XCTAssertEqual(token.expiresIn, 3600)
+  }
+
+  func testRevokeCallsDelete() async throws {
+    final class Counter { var deletes = 0 }
+    let ctr = Counter()
+    let transport = ClosureTransport { _, _, _, operationID in
+      if operationID == "apiTokenDelete" { ctr.deletes += 1; return (HTTPResponse(status: .noContent), nil) }
+      return (HTTPResponse(status: .ok), nil)
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    try await client.revokeAccessToken()
+    XCTAssertEqual(ctr.deletes, 1)
+  }
+}


### PR DESCRIPTION
Implements OAuth/PKCE helpers.

- Public PKCE utilities: code verifier + S256 challenge.
- Authorization URL builder with scopes, redirect URI, state, username.
- Token exchange via `/api/token`, revoke via `DELETE /api/token`, token test wrapper.
- Unit tests (mocked transport) for PKCE, token exchange, revoke.
- README section showing login flow.

Closes #2