### PR TITLE
feat(streaming): NDJSON decoding helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,24 @@ let client = LichessClient(configuration: .init(
   // middlewares: [MyMiddleware()]
 ))
 ```
+
+## Streams (NDJSON)
+
+```swift
+import LichessClient
+
+let client = LichessClient()
+
+// Example: consume official broadcasts stream
+let stream = try await client.broadcastIndex(nb: 5)
+for try await t in stream {
+  print(t.tour.name)
+}
+
+// Or decode any NDJSON HTTPBody into a typed stream
+struct Item: Decodable { let a: Int }
+let body: HTTPBody = HTTPBody("{\"a\":1}\n{\"a\":2}\n")
+for try await item in Streaming.ndjsonStream(from: body, as: Item.self) {
+  print(item)
+}
+```

--- a/Sources/LichessClient/Streaming.swift
+++ b/Sources/LichessClient/Streaming.swift
@@ -1,0 +1,30 @@
+import Foundation
+import OpenAPIRuntime
+
+public enum Streaming {
+
+  /// Decode an HTTPBody containing Newline-Delimited JSON (NDJSON) into a typed AsyncThrowingStream.
+  /// The returned stream supports cancellation; cancelling the consumer task cancels the decoding task.
+  public static func ndjsonStream<T: Decodable>(
+    from body: HTTPBody,
+    as type: T.Type = T.self,
+    decoder: JSONDecoder = .init()
+  ) -> AsyncThrowingStream<T, Error> {
+    let sequence = body.asDecodedJSONLines(of: T.self, decoder: decoder)
+    return AsyncThrowingStream(T.self) { continuation in
+      let task = Task {
+        do {
+          for try await event in sequence {
+            if Task.isCancelled { break }
+            continuation.yield(event)
+          }
+          continuation.finish()
+        } catch {
+          continuation.finish(throwing: error)
+        }
+      }
+      continuation.onTermination = { _ in task.cancel() }
+    }
+  }
+}
+

--- a/Tests/LichessClientTests/StreamingTests.swift
+++ b/Tests/LichessClientTests/StreamingTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+
+final class StreamingTests: XCTestCase {
+
+  struct Item: Codable, Equatable { let a: Int }
+
+  func testDecodeTwoItems() async throws {
+    let ndjson = "{" + "\"a\":1}" + "\n{" + "\"a\":2}" + "\n"
+    let body = HTTPBody(ndjson)
+    var received: [Item] = []
+    for try await item in Streaming.ndjsonStream(from: body, as: Item.self) {
+      received.append(item)
+    }
+    XCTAssertEqual(received, [Item(a: 1), Item(a: 2)])
+  }
+
+  func testCancellationStopsConsumer() async throws {
+    // Build a slow NDJSON producer
+    let stream = AsyncStream(HTTPBody.ByteChunk.self) { continuation in
+      continuation.yield(ArraySlice("{\"a\":1}\n".utf8))
+      // then produce many more lines slowly on a detached task
+      Task.detached {
+        for i in 2...1000 {
+          try? await Task.sleep(nanoseconds: 50_000_000) // 50ms
+          continuation.yield(ArraySlice("{\"a\":\(i)}\n".utf8))
+        }
+        continuation.finish()
+      }
+    }
+    let body = HTTPBody(stream, length: .unknown)
+    let streamSeq = Streaming.ndjsonStream(from: body, as: Item.self)
+
+    // Consume first two items, then cancel
+    var count = 0
+    let consumer = Task {
+      for try await _ in streamSeq {
+        count += 1
+        if count == 2 { break }
+      }
+    }
+    try await consumer.value
+    let before = count
+    // wait a bit to see if more items accumulate despite we stopped consuming
+    try await Task.sleep(nanoseconds: 120_000_000)
+    XCTAssertEqual(count, before)
+  }
+}
+


### PR DESCRIPTION
Reusable NDJSON decoding utilities and examples.

- `Streaming.ndjsonStream(from:as:)` converts `HTTPBody` to `AsyncThrowingStream<T: Decodable>`, with cancellation propagation.
- Unit tests cover decoding and cancellation behavior.
- README updated with stream consumption examples.

Refs #3