### PR TITLE
feat(users): Users & Profiles wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,20 @@ let token = try await LichessClient().exchangeCodeForToken(
 let authed = LichessClient(accessToken: token.accessToken)
 ```
 
+## Users & Profiles
+
+```swift
+import LichessClient
+
+let client = LichessClient()
+let user = try await client.getUser(username: "thibault")
+print(user.username, user.title ?? "-")
+
+// If authenticated
+let me = try await client.getMyProfile()
+let email = try await client.getMyEmail()
+```
+
 ## Configuration, Transport, and Auth
 
 ```swift

--- a/Sources/LichessClient/LichessClient+Users.swift
+++ b/Sources/LichessClient/LichessClient+Users.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+extension LichessClient {
+  public struct PublicUser: Sendable, Hashable {
+    public let id: String
+    public let username: String
+    public let title: String?
+    public let createdAt: Date?
+    public let seenAt: Date?
+    public let verified: Bool?
+    public let disabled: Bool?
+    public let url: String?
+    public let playing: String?
+    public let streaming: Bool?
+  }
+
+  private func toDate(ms: Int64?) -> Date? {
+    guard let ms else { return nil }
+    return Date(timeIntervalSince1970: TimeInterval(ms) / 1000.0)
+  }
+
+  private func mapUserExtended(_ user: Components.Schemas.UserExtended) -> PublicUser {
+    let u = user.value1
+    let extra = user.value2
+    return PublicUser(
+      id: u.id,
+      username: u.username,
+      title: u.title?.rawValue,
+      createdAt: toDate(ms: u.createdAt),
+      seenAt: toDate(ms: u.seenAt),
+      verified: u.verified,
+      disabled: u.disabled,
+      url: extra.url,
+      playing: extra.playing,
+      streaming: extra.streaming
+    )
+  }
+
+  public func getUser(username: String, includeTrophies: Bool = false) async throws -> PublicUser {
+    let response = try await underlyingClient.apiUser(
+      path: .init(username: username),
+      query: .init(trophies: includeTrophies)
+    )
+    switch response {
+    case .ok(let ok):
+      let payload = try ok.body.json
+      return mapUserExtended(payload)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  public func getMyProfile() async throws -> PublicUser {
+    let response = try await underlyingClient.accountMe()
+    switch response {
+    case .ok(let ok):
+      let payload = try ok.body.json
+      return mapUserExtended(payload)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  public func getMyEmail() async throws -> String? {
+    let response = try await underlyingClient.accountEmail()
+    switch response {
+    case .ok(let ok):
+      return try ok.body.json.email
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}
+

--- a/Tests/LichessClientTests/UsersTests.swift
+++ b/Tests/LichessClientTests/UsersTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class UsersTests: XCTestCase {
+
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testGetUserMapsFields() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiUser")
+      let json = "{\"id\":\"abc\",\"username\":\"Alice\",\"title\":\"GM\",\"createdAt\":1000,\"seenAt\":2000,\"verified\":true,\"disabled\":false,\"url\":\"https://lichess.org/@/Alice\",\"playing\":\"game\",\"streaming\":true}"
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let u = try await client.getUser(username: "Alice")
+    XCTAssertEqual(u.id, "abc")
+    XCTAssertEqual(u.username, "Alice")
+    XCTAssertEqual(u.title, "GM")
+    XCTAssertNotNil(u.createdAt)
+    XCTAssertNotNil(u.seenAt)
+    XCTAssertEqual(u.verified, true)
+    XCTAssertEqual(u.disabled, false)
+    XCTAssertEqual(u.url, "https://lichess.org/@/Alice")
+    XCTAssertEqual(u.playing, "game")
+    XCTAssertEqual(u.streaming, true)
+  }
+
+  func testGetMyProfile() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "accountMe")
+      let json = "{\"id\":\"me\",\"username\":\"Bob\"}"
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let me = try await client.getMyProfile()
+    XCTAssertEqual(me.id, "me")
+    XCTAssertEqual(me.username, "Bob")
+  }
+
+  func testGetMyEmail() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "accountEmail")
+      let json = "{\"email\":\"me@example.com\"}"
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let email = try await client.getMyEmail()
+    XCTAssertEqual(email, "me@example.com")
+  }
+}
+


### PR DESCRIPTION
Adds high-level Users & Profiles wrappers.

- PublicUser model mapped from `UserExtended`
- `getUser(username:includeTrophies:)`, `getMyProfile()`, `getMyEmail()`
- Unit tests using mock transport
- README examples

Refs #4