### PR TITLE
Fix: correct tablebase variant_loss mapping in standard lookup

### DIFF
--- a/Sources/LichessClient/LichessClient+Tablebase.swift
+++ b/Sources/LichessClient/LichessClient+Tablebase.swift
@@ -114,7 +114,7 @@ extension LichessClient {
         var tablebaseLookup = TablebaseLookup(
           dtz: tablebaseJson.dtz, precise_dtz: tablebaseJson.precise_dtz, dtm: tablebaseJson.dtm,
           checkmate: tablebaseJson.checkmate, stalemate: tablebaseJson.stalemate,
-          variant_win: tablebaseJson.variant_win, variant_loss: tablebaseJson.variant_win,
+          variant_win: tablebaseJson.variant_win, variant_loss: tablebaseJson.variant_loss,
           insufficient_material: tablebaseJson.insufficient_material,
           category: convertCategoryTablebaseJson(payload: tablebaseJson.category), moves: [])
 


### PR DESCRIPTION
This PR fixes a bug where `variant_loss` was incorrectly assigned from `variant_win` in `getStandardTablebase`, leading to wrong variant flags in tablebase responses.

- Updated mapping to use `tablebaseJson.variant_loss`
- Verified via existing tests (`swift test`) which continue to pass

Closes #16