### PR TITLE
Feat: Puzzles API wrappers (daily and by-id)

### DIFF
--- a/Sources/LichessClient/LichessClient+Puzzles.swift
+++ b/Sources/LichessClient/LichessClient+Puzzles.swift
@@ -99,4 +99,15 @@ extension LichessClient {
       throw LichessClientError.undocumentedResponse(statusCode: statusCode)
     }
   }
+
+  public func getNextPuzzle(angle: String? = nil) async throws -> PuzzleAndGame {
+    let response = try await underlyingClient.apiPuzzleNext(query: .init(angle: angle))
+    switch response {
+    case .ok(let okResponse):
+      let payload = try okResponse.body.json
+      return convert(payload)
+    case .undocumented(let statusCode, _):
+      throw LichessClientError.undocumentedResponse(statusCode: statusCode)
+    }
+  }
 }

--- a/Tests/LichessClientTests/PuzzlesTests.swift
+++ b/Tests/LichessClientTests/PuzzlesTests.swift
@@ -26,5 +26,22 @@ final class PuzzlesTests: XCTestCase {
     XCTAssertGreaterThan(byId.puzzle.solution.count, 0)
     XCTAssertFalse(byId.game.id.isEmpty)
   }
-}
 
+  func testNextPuzzleFetchWorksOrSkipsIfUnauthorized() async throws {
+    let client = LichessClient()
+    do {
+      let next = try await client.getNextPuzzle()
+      XCTAssertFalse(next.puzzle.id.isEmpty)
+      XCTAssertFalse(next.game.id.isEmpty)
+    } catch let error as LichessClient.LichessClientError {
+      switch error {
+      case .undocumentedResponse(let statusCode) where statusCode == 401:
+        throw XCTSkip("Requires puzzle:read scope; skipping in anonymous environment")
+      default:
+        throw error
+      }
+    } catch {
+      throw error
+    }
+  }
+}


### PR DESCRIPTION
Adds lightweight wrappers for Puzzles endpoints to simplify consumption of daily puzzle, puzzle by ID, and next puzzle.

- New public types: `Puzzle`, `PuzzleGame`, `PuzzleGamePlayer`, `PuzzleGamePerf`, `PuzzleAndGame`
- `getDailyPuzzle()` returns the current `PuzzleAndGame`
- `getPuzzle(id:)` returns a specific `PuzzleAndGame`
- `getNextPuzzle(angle:)` returns a random `PuzzleAndGame`, with optional theme filter
- Mirrors error handling style of other helpers
- Adds unit tests for daily, by-id, and next puzzle wrappers

Closes #5