### PR TITLE
Feat: Game and TV NDJSON stream wrappers

### DIFF
--- a/Sources/LichessClient/LichessClient+Streams.swift
+++ b/Sources/LichessClient/LichessClient+Streams.swift
@@ -1,0 +1,36 @@
+//
+//  LichessClient+Streams.swift
+//
+
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  /// Stream positions and moves of any ongoing game as NDJSON.
+  /// Returns the raw NDJSON HTTPBody; use `Streaming.ndjsonStream` to decode lines.
+  public func streamGame(gameId: String) async throws -> HTTPBody {
+    let response = try await underlyingClient.streamGame(
+      .init(path: .init(id: gameId))
+    )
+    switch response {
+    case .ok(let okResponse):
+      return try okResponse.body.application_x_hyphen_ndjson
+    case .tooManyRequests:
+      throw LichessClientError.undocumentedResponse(statusCode: 429)
+    case .undocumented(let statusCode, _):
+      throw LichessClientError.undocumentedResponse(statusCode: statusCode)
+    }
+  }
+
+  /// Stream positions and moves of the current TV game as NDJSON.
+  /// Returns the raw NDJSON HTTPBody; use `Streaming.ndjsonStream` to decode lines.
+  public func streamTVFeed() async throws -> HTTPBody {
+    let response = try await underlyingClient.tvFeed(.init())
+    switch response {
+    case .ok(let okResponse):
+      return try okResponse.body.application_x_hyphen_ndjson
+    case .undocumented(let statusCode, _):
+      throw LichessClientError.undocumentedResponse(statusCode: statusCode)
+    }
+  }
+}


### PR DESCRIPTION
Adds minimal wrappers for game and TV streams to expose raw NDJSON bodies for consumer-side decoding.

- `streamGame(gameId:)` -> returns `HTTPBody` with `application/x-ndjson`
- `streamTVFeed()` -> returns `HTTPBody` with `application/x-ndjson`
- Designed to be used with `Streaming.ndjsonStream` utility for decoding lines into typed events
- Includes basic 429 handling for game stream

Closes #6