### PR TITLE
Feat: Error modeling + rate limit backoff

### DIFF
--- a/Sources/LichessClient/LichessClient+Studies.swift
+++ b/Sources/LichessClient/LichessClient+Studies.swift
@@ -118,7 +118,7 @@ extension LichessClient {
       let chapters: [StudyImportChapter] = (payload.chapters ?? []).map { ch in
         let players = ch.players?.map { StudyImportPlayer(name: $0.name, rating: $0.rating) }
         return StudyImportChapter(id: ch.id, name: ch.name, players: players, status: ch.status)
-      } ?? []
+      }
       return StudyImportResult(chapters: chapters)
     case .badRequest(let bad):
       // Bubble up server-provided error message if available
@@ -129,4 +129,3 @@ extension LichessClient {
     }
   }
 }
-


### PR DESCRIPTION
Adds structured errors and a rate limiting middleware to improve resilience.

- `LichessClientError` now includes common HTTP cases (401/403/404/429)
- `RateLimitMiddleware` honors `Retry-After` and retries with backoff (configurable)
- `LichessClient.Configuration` gains `rateLimitPolicy` to enable and tune behavior

Closes #11