### PR TITLE
Docs: usage examples and overhaul

### DIFF
--- a/Examples/PuzzlesExample/main.swift
+++ b/Examples/PuzzlesExample/main.swift
@@ -1,0 +1,22 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let daily = try await client.getDailyPuzzle()
+      print("Daily puzzle:", daily.puzzle.id, "rating:", daily.puzzle.rating)
+
+      let byId = try await client.getPuzzle(id: daily.puzzle.id)
+      print("By-ID perf:", byId.game.perf.name)
+
+      let next = try await client.getNextPuzzle(angle: nil)
+      print("Next puzzle:", next.puzzle.id)
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Examples/TVStreamExample/main.swift
+++ b/Examples/TVStreamExample/main.swift
@@ -1,0 +1,23 @@
+import Foundation
+import LichessClient
+
+struct TVEvent: Decodable { let type: String?; let id: String? }
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let body = try await client.streamTVFeed()
+      var count = 0
+      for try await evt in Streaming.ndjsonStream(from: body, as: TVEvent.self) {
+        print("event:", evt.type ?? "?", "id:", evt.id ?? "-")
+        count += 1
+        if count >= 1 { break }
+      }
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -25,6 +25,16 @@ let package = Package(
                 .enableExperimentalFeature("StrictConcurrency")
             ]
         ),
+        .executableTarget(
+            name: "PuzzlesExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/PuzzlesExample"
+        ),
+        .executableTarget(
+            name: "TVStreamExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/TVStreamExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),


### PR DESCRIPTION
Overhauls README with practical examples across major areas, and adds runnable examples.

- Puzzles: daily/by-id/next (+ PuzzlesExample)
- Tablebase: standard + variants
- Streams: game + TV (+ TVStreamExample)
- Opening Explorer: masters, lichess, player stream
- Tournaments & Swiss: exports and results streams
- Studies: PGN export/list/import
- Diagnostics & Resilience: logging, retry, rate limit

Closes #13