### PR TITLE
TV API coverage: channels, channel feed, channel games (PGN/NDJSON)

### DIFF
--- a/Examples/TVChannelsExample/main.swift
+++ b/Examples/TVChannelsExample/main.swift
@@ -1,0 +1,23 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let channels = try await client.getTVChannels()
+      for (channel, game) in channels.entries {
+        print("\(channel.rawValue): \(game.user.name) (\(game.rating)) id=\(game.gameId) color=\(game.color)")
+      }
+
+      // Fetch a few Blitz games in PGN
+      let body = try await client.getTVChannelGames(channel: "blitz", format: .pgn, nb: 3)
+      let pgn = try await String(collecting: body, upTo: 4096)
+      print("Sample PGN first chars:\n", pgn.prefix(120))
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/TVStreamExample"
         ),
+        .executableTarget(
+            name: "TVChannelsExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/TVChannelsExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -149,6 +149,18 @@ let tvBody = try await client.streamTVFeed()
 for try await evt in Streaming.ndjsonStream(from: tvBody, as: Components.Schemas.GameFullEvent.self) {
   print(evt.id)
 }
+
+// TV channels and per-channel games
+let tv = try await client.getTVChannels()
+for (channel, game) in tv.entries { print(channel, game.user.name, game.rating) }
+
+// Stream a specific channel feed (NDJSON)
+let chBody = try await client.streamTVChannelFeed(channel: "rapid")
+struct TVMin: Decodable { let t: String? }
+for try await item in Streaming.ndjsonStream(from: chBody, as: TVMin.self) { print(item.t ?? "-"); break }
+
+// Fetch best ongoing Blitz games (PGN or NDJSON via `format`)
+_ = try await client.getTVChannelGames(channel: "blitz", format: .pgn, nb: 10)
 ```
 
 ## Opening Explorer (Masters, Lichess, Player DB)

--- a/Sources/LichessClient/LichessClient+TV.swift
+++ b/Sources/LichessClient/LichessClient+TV.swift
@@ -1,0 +1,157 @@
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  // MARK: - Public types
+
+  public enum TVChannel: String, Codable, CaseIterable, Sendable {
+    case bot, blitz, racingKings, ultraBullet, bullet, classical, threeCheck, antichess, computer, horde, rapid, atomic, crazyhouse, chess960, kingOfTheHill, best
+  }
+
+  public struct TVUser: Codable, Sendable, Hashable {
+    public let id: String
+    public let name: String
+    public let flair: String?
+    public let title: String?
+    public let patron: Bool?
+  }
+
+  public struct TVGame: Codable, Sendable, Hashable {
+    public let user: TVUser
+    public let rating: Int
+    public let gameId: String
+    public let color: String
+  }
+
+  public struct TVChannels: Codable, Sendable, Hashable {
+    public let entries: [TVChannel: TVGame]
+  }
+
+  public enum TVFeedEvent: Sendable, Hashable {
+    case featured(Featured)
+    case fen(FEN)
+
+    public struct Player: Codable, Sendable, Hashable {
+      public let color: String
+      public let user: TVUser
+      public let rating: Int
+      public let seconds: Int
+    }
+
+    public struct Featured: Codable, Sendable, Hashable {
+      public let id: String
+      public let orientation: String
+      public let players: [Player] // always 2
+      public let fen: String
+    }
+
+    public struct FEN: Codable, Sendable, Hashable {
+      public let fen: String
+      public let lm: String
+      public let wc: Int
+      public let bc: Int
+    }
+  }
+
+  // MARK: - Helpers (mapping generator payloads)
+
+  private func mapLightUser(_ u: Components.Schemas.LightUser) -> TVUser {
+    TVUser(id: u.id, name: u.name, flair: u.flair, title: u.title?.rawValue, patron: u.patron)
+  }
+
+  private func mapTvGame(_ g: Components.Schemas.TvGame) -> TVGame {
+    TVGame(user: mapLightUser(g.user), rating: Int(g.rating), gameId: g.gameId, color: g.color.rawValue)
+  }
+
+  // MARK: - Public API
+
+  /// Get the current Lichess TV channels with their featured games.
+  public func getTVChannels() async throws -> TVChannels {
+    let resp = try await underlyingClient.tvChannels()
+    switch resp {
+    case .ok(let ok):
+      let payload = try ok.body.json
+      var dict: [TVChannel: TVGame] = [:]
+      dict[.bot] = mapTvGame(payload.bot)
+      dict[.blitz] = mapTvGame(payload.blitz)
+      dict[.racingKings] = mapTvGame(payload.racingKings)
+      dict[.ultraBullet] = mapTvGame(payload.ultraBullet)
+      dict[.bullet] = mapTvGame(payload.bullet)
+      dict[.classical] = mapTvGame(payload.classical)
+      dict[.threeCheck] = mapTvGame(payload.threeCheck)
+      dict[.antichess] = mapTvGame(payload.antichess)
+      dict[.computer] = mapTvGame(payload.computer)
+      dict[.horde] = mapTvGame(payload.horde)
+      dict[.rapid] = mapTvGame(payload.rapid)
+      dict[.atomic] = mapTvGame(payload.atomic)
+      dict[.crazyhouse] = mapTvGame(payload.crazyhouse)
+      dict[.chess960] = mapTvGame(payload.chess960)
+      dict[.kingOfTheHill] = mapTvGame(payload.kingOfTheHill)
+      dict[.best] = mapTvGame(payload.best)
+      return TVChannels(entries: dict)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Stream the current TV game for a given channel as NDJSON.
+  /// Returns the raw NDJSON body suitable for `Streaming.ndjsonStream`.
+  public func streamTVChannelFeed(channel: String) async throws -> HTTPBody {
+    let resp = try await underlyingClient.tvChannelFeed(path: .init(channel: channel))
+    switch resp {
+    case .ok(let ok):
+      return try ok.body.application_x_hyphen_ndjson
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Decode a `TVFeedEvent` from a single decoded NDJSON line provided by the generator.
+  static func decodeTVFeedEvent(_ v: Components.Schemas.TvFeed) -> TVFeedEvent? {
+    switch v.t {
+    case .featured:
+      guard case .case1(let d) = v.d else { return nil }
+      let players = d.players.map { p in
+        TVFeedEvent.Player(color: p.color.rawValue, user: TVUser(id: p.user.id, name: p.user.name, flair: p.user.flair, title: p.user.title?.rawValue, patron: p.user.patron), rating: p.rating, seconds: p.seconds)
+      }
+      return .featured(.init(id: d.id, orientation: d.orientation.rawValue, players: players, fen: d.fen))
+    case .fen:
+      guard case .case2(let d) = v.d else { return nil }
+      return .fen(.init(fen: d.fen, lm: d.lm, wc: d.wc, bc: d.bc))
+    }
+  }
+
+  /// Get best ongoing games for a specific TV channel. Returns PGN or NDJSON based on `format`.
+  public func getTVChannelGames(
+    channel: String,
+    format: ExportFormat = .pgn,
+    nb: Int? = nil,
+    moves: Bool? = nil,
+    pgnInJson: Bool? = nil,
+    tags: Bool? = nil,
+    clocks: Bool? = nil,
+    opening: Bool? = nil
+  ) async throws -> HTTPBody {
+    // Map export format to Accept header
+    let accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.tvChannelGames.AcceptableContentType>] = {
+      switch format {
+      case .pgn: return [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)]
+      case .ndjson: return [.init(contentType: .application_x_hyphen_ndjson)]
+      }
+    }()
+    let resp = try await underlyingClient.tvChannelGames(
+      path: .init(channel: channel),
+      query: .init(nb: nb.map(Double.init), moves: moves, pgnInJson: pgnInJson, tags: tags, clocks: clocks, opening: opening),
+      headers: .init(accept: accept)
+    )
+    switch resp {
+    case .ok(let ok):
+      switch ok.body {
+      case .application_x_hyphen_chess_hyphen_pgn(let body): return body
+      case .application_x_hyphen_ndjson(let body): return body
+      }
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/TVTests.swift
+++ b/Tests/LichessClientTests/TVTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class TVTests: XCTestCase {
+
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testGetTVChannelsMapsFields() async throws {
+    // Minimal valid JSON payload for tvChannels
+    let json = """
+    {"bot":{"user":{"id":"u1","name":"Alice"},"rating":2500,"gameId":"g1","color":"white"},
+     "blitz":{"user":{"id":"u2","name":"Bob"},"rating":2800,"gameId":"g2","color":"black"},
+     "racingKings":{"user":{"id":"u3","name":"C"},"rating":2000,"gameId":"g3","color":"white"},
+     "ultraBullet":{"user":{"id":"u4","name":"D"},"rating":1600,"gameId":"g4","color":"white"},
+     "bullet":{"user":{"id":"u5","name":"E"},"rating":3000,"gameId":"g5","color":"black"},
+     "classical":{"user":{"id":"u6","name":"F"},"rating":2200,"gameId":"g6","color":"white"},
+     "threeCheck":{"user":{"id":"u7","name":"G"},"rating":2100,"gameId":"g7","color":"black"},
+     "antichess":{"user":{"id":"u8","name":"H"},"rating":2300,"gameId":"g8","color":"white"},
+     "computer":{"user":{"id":"u9","name":"I"},"rating":1900,"gameId":"g9","color":"black"},
+     "horde":{"user":{"id":"u10","name":"J"},"rating":1950,"gameId":"g10","color":"white"},
+     "rapid":{"user":{"id":"u11","name":"K"},"rating":2400,"gameId":"g11","color":"white"},
+     "atomic":{"user":{"id":"u12","name":"L"},"rating":1800,"gameId":"g12","color":"black"},
+     "crazyhouse":{"user":{"id":"u13","name":"M"},"rating":2050,"gameId":"g13","color":"white"},
+     "chess960":{"user":{"id":"u14","name":"N"},"rating":2150,"gameId":"g14","color":"black"},
+     "kingOfTheHill":{"user":{"id":"u15","name":"O"},"rating":2250,"gameId":"g15","color":"white"},
+     "best":{"user":{"id":"u16","name":"P"},"rating":2850,"gameId":"g16","color":"black"}}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "tvChannels")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let chans = try await client.getTVChannels()
+    XCTAssertEqual(chans.entries[.bot]?.user.name, "Alice")
+    XCTAssertEqual(chans.entries[.blitz]?.rating, 2800)
+    XCTAssertEqual(chans.entries.count, 16)
+  }
+
+  func testTVChannelGamesAcceptHeader() async throws {
+    var seenAccept: String?
+    let transport = Transport { req, _, _, op in
+      XCTAssertEqual(op, "tvChannelGames")
+      seenAccept = req.headerFields[.accept]
+      return (HTTPResponse(status: .ok), HTTPBody("[{}]\n"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+
+    _ = try await client.getTVChannelGames(channel: "blitz", format: .ndjson, nb: 1)
+    XCTAssertTrue(seenAccept?.contains("application/x-ndjson") ?? false)
+  }
+
+  struct MinimalFeed: Decodable { let t: String? }
+  func testStreamTVChannelFeedReturnsNDJSON() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "tvChannelFeed")
+      return (HTTPResponse(status: .ok), HTTPBody("{\"t\":\"fen\"}\n"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let body = try await client.streamTVChannelFeed(channel: "rapid")
+    var gotLine = false
+    for try await item in Streaming.ndjsonStream(from: body, as: MinimalFeed.self) {
+      gotLine = true
+      XCTAssertEqual(item.t, "fen")
+      break
+    }
+    XCTAssertTrue(gotLine)
+  }
+}


### PR DESCRIPTION
Summary

This PR adds public API coverage for Lichess TV endpoints beyond the existing `streamTVFeed()`:

- `getTVChannels()` → typed mapping of channel → featured game
- `streamTVChannelFeed(channel:)` → NDJSON body for a specific channel
- `getTVChannelGames(channel:format:nb:moves:pgnInJson:tags:clocks:opening:)` → returns PGN or NDJSON based on `format` with explicit Accept selection

Details

- New file: `Sources/LichessClient/LichessClient+TV.swift`
  - Public models: `TVChannel`, `TVUser`, `TVGame`, `TVChannels`, and `TVFeedEvent` helper types
  - Internal mapping helpers to bridge generator types to public models
  - Accept header handling mirrors tournament/swiss APIs
- Examples:
  - New `TVChannelsExample` demonstrating channel listing and fetching Blitz games PGN
  - README updated with TV usage snippets
- Tests:
  - `TVTests` cover channel mapping, Accept header selection, and channel feed NDJSON handling

Notes

- Keeps generated types internal; wrappers expose stable, Swifty models.
- Leaves room for future decoding helpers to map NDJSON lines to `TVFeedEvent` if desired.

Closes the TV coverage gap outlined in the tracking issue.

closes #47