### PR TITLE
Players API coverage: Top-10 and perf leaderboard

### DIFF
--- a/Examples/PlayersExample/main.swift
+++ b/Examples/PlayersExample/main.swift
@@ -1,0 +1,21 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let top = try await client.getAllTop10()
+      print("Bullet top count:", top["bullet"]?.count ?? 0)
+
+      let blitz100 = try await client.getLeaderboard(perfType: "blitz", nb: 5)
+      if let first = blitz100.first {
+        print("Top Blitz:", first.username, first.rating)
+      }
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/TVChannelsExample"
         ),
+        .executableTarget(
+            name: "PlayersExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/PlayersExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ for try await item in Streaming.ndjsonStream(from: body, as: Item.self) {
 }
 ```
 
+## Players (Leaderboards)
+
+```swift
+let client = LichessClient()
+
+// All Top-10 lists per perf key
+let top = try await client.getAllTop10()
+print("Top-10 Bullet count:", top["bullet"]?.count ?? 0)
+
+// One leaderboard (up to 200 entries)
+let blitzTop = try await client.getLeaderboard(perfType: "blitz", nb: 50)
+print(blitzTop.first?.username ?? "-")
+```
+
 ## Puzzles
 
 ```swift

--- a/Sources/LichessClient/LichessClient+Players.swift
+++ b/Sources/LichessClient/LichessClient+Players.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+extension LichessClient {
+  public struct LeaderboardEntry: Codable, Sendable, Hashable {
+    public let id: String
+    public let username: String
+    public let title: String?
+    public let rating: Int
+    public let progress: Int
+    public let patron: Bool?
+    public let online: Bool?
+  }
+
+  /// Get the top 10 players for each speed and variant.
+  /// Returns a dictionary keyed by perf type (e.g. "bullet", "blitz").
+  public func getAllTop10() async throws -> [String: [LeaderboardEntry]] {
+    let resp = try await underlyingClient.player()
+    switch resp {
+    case .ok(let ok):
+      let top = try ok.body.json
+      func mapList(_ users: [Components.Schemas.TopUser], perf: String) -> [LeaderboardEntry] {
+        users.map { u in
+          let perfs = u.perfs?.additionalProperties ?? [:]
+          let perfStats = perfs[perf]
+          return LeaderboardEntry(
+            id: u.id,
+            username: u.username,
+            title: u.title?.rawValue,
+            rating: perfStats?.rating ?? 0,
+            progress: perfStats?.progress ?? 0,
+            patron: u.patron,
+            online: u.online
+          )
+        }
+      }
+      var dict: [String: [LeaderboardEntry]] = [:]
+      dict["bullet"] = mapList(top.bullet, perf: "bullet")
+      dict["blitz"] = mapList(top.blitz, perf: "blitz")
+      dict["rapid"] = mapList(top.rapid, perf: "rapid")
+      dict["classical"] = mapList(top.classical, perf: "classical")
+      dict["ultraBullet"] = mapList(top.ultraBullet, perf: "ultraBullet")
+      dict["crazyhouse"] = mapList(top.crazyhouse, perf: "crazyhouse")
+      dict["chess960"] = mapList(top.chess960, perf: "chess960")
+      dict["kingOfTheHill"] = mapList(top.kingOfTheHill, perf: "kingOfTheHill")
+      dict["threeCheck"] = mapList(top.threeCheck, perf: "threeCheck")
+      dict["antichess"] = mapList(top.antichess, perf: "antichess")
+      dict["atomic"] = mapList(top.atomic, perf: "atomic")
+      dict["horde"] = mapList(top.horde, perf: "horde")
+      dict["racingKings"] = mapList(top.racingKings, perf: "racingKings")
+      return dict
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Get the leaderboard for a single speed or variant.
+  /// - Parameters:
+  ///   - perfType: One of the Lichess perf keys (e.g. "bullet", "blitz").
+  ///   - nb: Number of users (1...200).
+  public func getLeaderboard(perfType: String, nb: Int = 100) async throws -> [LeaderboardEntry] {
+    let key = Operations.playerTopNbPerfType.Input.Path.perfTypePayload(rawValue: perfType) ?? .blitz
+    let resp = try await underlyingClient.playerTopNbPerfType(path: .init(nb: max(1, min(200, nb)), perfType: key))
+    switch resp {
+    case .ok(let ok):
+      let lb = try ok.body.application_vnd_period_lichess_period_v3_plus_json
+      let perf = perfType
+      return lb.users.map { u in
+        let perfs = u.perfs?.additionalProperties ?? [:]
+        let p = perfs[perf]
+        return LeaderboardEntry(
+          id: u.id,
+          username: u.username,
+          title: u.title?.rawValue,
+          rating: p?.rating ?? 0,
+          progress: p?.progress ?? 0,
+          patron: u.patron,
+          online: u.online
+        )
+      }
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}
+

--- a/Tests/LichessClientTests/PlayersTests.swift
+++ b/Tests/LichessClientTests/PlayersTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class PlayersTests: XCTestCase {
+
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testGetLeaderboardMapsFields() async throws {
+    let json = """
+    {"users":[{"id":"u1","username":"Alice","perfs":{"blitz":{"rating":2900,"progress":5}},"title":"GM"}]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "playerTopNbPerfType")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let list = try await client.getLeaderboard(perfType: "blitz", nb: 1)
+    XCTAssertEqual(list.count, 1)
+    XCTAssertEqual(list.first?.username, "Alice")
+    XCTAssertEqual(list.first?.rating, 2900)
+    XCTAssertEqual(list.first?.title, "GM")
+  }
+
+  func testGetAllTop10BuildsDictionary() async throws {
+    // Provide minimal payload: all fields required by Top10s, mostly empty arrays except bullet
+    let json = """
+    {"bullet":[{"id":"u1","username":"A","perfs":{"bullet":{"rating":3200,"progress":10}}}],
+     "blitz":[],"rapid":[],"classical":[],"ultraBullet":[],"crazyhouse":[],"chess960":[],
+     "kingOfTheHill":[],"threeCheck":[],"antichess":[],"atomic":[],"horde":[],"racingKings":[]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "player")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let top = try await client.getAllTop10()
+    XCTAssertEqual(top["bullet"]?.first?.rating, 3200)
+    XCTAssertEqual(top.keys.count, 13)
+  }
+}
+


### PR DESCRIPTION
Summary

This PR adds public API coverage for Lichess Players endpoints:

- `getAllTop10()` → maps Top-10 lists for each speed/variant to a `[String: [LeaderboardEntry]]`
- `getLeaderboard(perfType:nb:)` → returns a typed list for a single perf (1…200 entries)

Details

- New: `Sources/LichessClient/LichessClient+Players.swift` with `LeaderboardEntry` model and helpers
- Examples: `PlayersExample` demonstrates Top-10 and Blitz leaderboard
- README: added “Players (Leaderboards)” usage section
- Tests: `PlayersTests` validate mapping and input selection

Notes

- Keeps generator types internal; wrappers expose stable models (`LeaderboardEntry`).
- PerfType is bridged to string keys (e.g. "blitz", "bullet").

closes #48