### PR TITLE
Cloud Evaluation API coverage: getCloudEval(fen:multiPv:variant:)

### DIFF
--- a/Examples/CloudEvalExample/main.swift
+++ b/Examples/CloudEvalExample/main.swift
@@ -1,0 +1,21 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let fen = "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3"
+      if let eval = try await client.getCloudEval(fen: fen, multiPv: 3) {
+        print("depth=\(eval.depth) knodes=\(eval.knodes)")
+        if let best = eval.pvs.first { print("best:", best.moves.prefix(5).joined(separator: " ")) }
+      } else {
+        print("No cloud eval for position")
+      }
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/PlayersExample"
         ),
+        .executableTarget(
+            name: "CloudEvalExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/CloudEvalExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -254,6 +254,17 @@ let importResult = try await client.importPGNIntoStudy(studyId: "lXnKRxIP", pgn:
 print(importResult.chapters.map { $0?.name ?? "-" })
 ```
 
+## Cloud Evaluation
+
+```swift
+let client = LichessClient()
+let fen = "r1bqkbnr/pppp1ppp/2n5/1B2p3/4P3/5N2/PPPP1PPP/RNBQK2R b KQkq - 3 3"
+if let eval = try await client.getCloudEval(fen: fen, multiPv: 3) {
+  print("depth=\(eval.depth) knodes=\(eval.knodes)")
+  print(eval.pvs.first?.moves.joined(separator: " ") ?? "-")
+}
+```
+
 ## Diagnostics & Resilience
 
 ```swift

--- a/Sources/LichessClient/LichessClient+CloudEval.swift
+++ b/Sources/LichessClient/LichessClient+CloudEval.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension LichessClient {
+  public struct CloudEvalPV: Codable, Sendable, Hashable {
+    public let cp: Int?
+    public let mate: Int?
+    public let moves: [String]
+  }
+
+  public struct CloudEvalResult: Codable, Sendable, Hashable {
+    public let depth: Int
+    public let knodes: Int
+    public let fen: String
+    public let pvs: [CloudEvalPV]
+  }
+
+  /// Get the cached cloud evaluation of a FEN, if available.
+  /// - Parameters:
+  ///   - fen: Position FEN.
+  ///   - multiPv: Number of variations to fetch (default 1).
+  ///   - variant: Optional variant key (e.g. "standard", "chess960").
+  public func getCloudEval(fen: String, multiPv: Int? = nil, variant: String? = nil) async throws -> CloudEvalResult? {
+    let variantKey = variant.flatMap { Components.Schemas.VariantKey(rawValue: $0) }
+    let resp = try await underlyingClient.apiCloudEval(
+      query: .init(fen: fen, multiPv: multiPv.map(Double.init), variant: variantKey)
+    )
+    switch resp {
+    case .ok(let ok):
+      let src = try ok.body.json
+      let pvs: [CloudEvalPV] = src.pvs.map { pv in
+        switch pv {
+        case .case1(let cpv):
+          return CloudEvalPV(cp: cpv.cp, mate: nil, moves: cpv.moves.split(separator: " ").map(String.init))
+        case .case2(let mpv):
+          return CloudEvalPV(cp: nil, mate: mpv.mate, moves: mpv.moves.split(separator: " ").map(String.init))
+        }
+      }
+      return CloudEvalResult(depth: src.depth, knodes: src.knodes, fen: src.fen, pvs: pvs)
+    case .notFound:
+      return nil
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}
+

--- a/Tests/LichessClientTests/CloudEvalTests.swift
+++ b/Tests/LichessClientTests/CloudEvalTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class CloudEvalTests: XCTestCase {
+
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testCloudEvalCpPV() async throws {
+    let json = """
+    {"depth":22,"fen":"F","knodes":1234,"pvs":[{"cp":34,"moves":"e2e4 e7e5 g1f3"}]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiCloudEval")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.getCloudEval(fen: "F")
+    XCTAssertNotNil(res)
+    XCTAssertEqual(res?.depth, 22)
+    XCTAssertEqual(res?.pvs.first?.cp, 34)
+    XCTAssertEqual(res?.pvs.first?.moves.prefix(2), ["e2e4","e7e5"])
+  }
+
+  func testCloudEvalMatePV() async throws {
+    let json = """
+    {"depth":30,"fen":"F","knodes":999,"pvs":[{"mate":3,"moves":"h7h8q g8h7 h8g8#"}]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiCloudEval")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.getCloudEval(fen: "F")
+    XCTAssertEqual(res?.pvs.first?.mate, 3)
+    XCTAssertTrue(res?.pvs.first?.moves.contains("h8g8#") ?? false)
+  }
+
+  func testCloudEvalNotFound() async throws {
+    let transport = Transport { _, _, _, _ in
+      var resp = HTTPResponse(status: .notFound)
+      return (resp, HTTPBody("{\"error\":\"No cloud evaluation available for that position\"}"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.getCloudEval(fen: "X")
+    XCTAssertNil(res)
+  }
+}
+


### PR DESCRIPTION
Summary

This PR adds public API coverage for the Cloud Evaluation endpoint:

- `getCloudEval(fen:multiPv:variant:)` → returns `CloudEvalResult?` (nil on 404) with typed PVs (centipawn or mate)

Details

- New: `Sources/LichessClient/LichessClient+CloudEval.swift` with `CloudEvalResult` and `CloudEvalPV` models
- Examples: `CloudEvalExample` demonstrates fetching a FEN with `multiPv: 3`
- README: added “Cloud Evaluation” section
- Tests: `CloudEvalTests` cover cp PV, mate PV, and 404 not-found

Notes

- Preserves generator types as internal; wrapper exposes stable, Swifty types.

closes #49