### PR TITLE
Crosstable API coverage: getCrosstable(user1:user2:matchup:)

### DIFF
--- a/Examples/CrosstableExample/main.swift
+++ b/Examples/CrosstableExample/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let ct = try await client.getCrosstable(user1: "drnykterstein", user2: "rebeccaharris")
+      print("games=\(ct.nbGames) scores=\(ct.scores)")
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/CloudEvalExample"
         ),
+        .executableTarget(
+            name: "CrosstableExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/CrosstableExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -135,6 +135,14 @@ let next = try await client.getNextPuzzle(angle: "mateIn2")
 print(next.puzzle.id)
 ```
 
+## Crosstable
+
+```swift
+let client = LichessClient()
+let ct = try await client.getCrosstable(user1: "drnykterstein", user2: "rebeccaharris")
+print(ct.nbGames, ct.scores)
+```
+
 ## Tablebase (Standard, Atomic, Antichess)
 
 ```swift

--- a/Sources/LichessClient/LichessClient+Crosstable.swift
+++ b/Sources/LichessClient/LichessClient+Crosstable.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+extension LichessClient {
+  public struct Crosstable: Codable, Sendable, Hashable {
+    /// Mapping of username → score (Double).
+    public let scores: [String: Double]
+    public let nbGames: Int
+  }
+
+  /// Get crosstable between two users. Optionally include current match data via `matchup: true`.
+  public func getCrosstable(user1: String, user2: String, matchup: Bool? = nil) async throws -> Crosstable {
+    let resp = try await underlyingClient.apiCrosstable(
+      path: .init(user1: user1, user2: user2),
+      query: .init(matchup: matchup)
+    )
+    switch resp {
+    case .ok(let ok):
+      let json = try ok.body.json
+      return Crosstable(scores: json.users.additionalProperties, nbGames: json.nbGames)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/CrosstableTests.swift
+++ b/Tests/LichessClientTests/CrosstableTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class CrosstableTests: XCTestCase {
+
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testGetCrosstableMapsFields() async throws {
+    let json = """
+    {"users":{"alice":10.5,"bob":9.5},"nbGames":20}
+    """
+    let transport = Transport { req, _, _, op in
+      XCTAssertEqual(op, "apiCrosstable")
+      XCTAssertTrue((req.path ?? "").contains("/api/crosstable/alice/bob"))
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let ct = try await client.getCrosstable(user1: "alice", user2: "bob")
+    XCTAssertEqual(ct.nbGames, 20)
+    XCTAssertEqual(ct.scores["alice"], 10.5)
+    XCTAssertEqual(ct.scores["bob"], 9.5)
+  }
+}


### PR DESCRIPTION
Summary

This PR adds public API coverage for the Crosstable endpoint:

- `getCrosstable(user1:user2:matchup:)` → returns scores by username and total game count

Details

- New: `Sources/LichessClient/LichessClient+Crosstable.swift` with a small public model
- Examples: `CrosstableExample` shows a real pair
- README: added “Crosstable” usage section
- Tests: `CrosstableTests` verify path construction and mapping

Notes

- Keeps generator types internal; wrapper exposes a stable map `{ username: score }` and `nbGames`.

closes #50