### PR TITLE
Simuls API coverage: getSimuls()

### DIFF
--- a/Examples/SimulsExample/main.swift
+++ b/Examples/SimulsExample/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let s = try await client.getSimuls()
+      print("created=\(s.created.count) started=\(s.started.count)")
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -55,6 +55,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/CrosstableExample"
         ),
+        .executableTarget(
+            name: "SimulsExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/SimulsExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -284,3 +284,10 @@ let client = LichessClient(configuration: .init(
   rateLimitPolicy: .init(maxRetries: 1, defaultDelaySeconds: 60)
 ))
 ```
+## Simuls
+
+```swift
+let client = LichessClient()
+let simuls = try await client.getSimuls()
+print(simuls.created.count, simuls.started.count)
+```

--- a/Sources/LichessClient/LichessClient+Simuls.swift
+++ b/Sources/LichessClient/LichessClient+Simuls.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+extension LichessClient {
+  public struct SimulVariant: Codable, Sendable, Hashable { public let key: String?; public let name: String?; public let icon: String? }
+  public struct SimulHost: Codable, Sendable, Hashable { public let id: String; public let name: String; public let rating: Int?; public let online: Bool? }
+  public struct SimulSummary: Codable, Sendable, Hashable {
+    public let id: String
+    public let name: String
+    public let fullName: String
+    public let host: SimulHost
+    public let variants: [SimulVariant]
+    public let isCreated: Bool
+    public let isRunning: Bool
+    public let isFinished: Bool
+    public let text: String?
+    public let estimatedStartAt: Int?
+    public let startedAt: Int?
+    public let finishedAt: Int?
+    public let nbApplicants: Int
+    public let nbPairings: Int
+  }
+
+  public struct SimulsResponse: Codable, Sendable, Hashable {
+    public let created: [SimulSummary]
+    public let started: [SimulSummary]
+    public let finished: [SimulSummary]
+    public let pending: [SimulSummary]
+  }
+
+  /// Get recent and ongoing simuls. If authenticated, includes your pending simuls.
+  public func getSimuls() async throws -> SimulsResponse {
+    let resp = try await underlyingClient.apiSimul()
+    switch resp {
+    case .ok(let ok):
+      let json = try ok.body.json
+      func mapOne(_ s: Components.Schemas.Simul) -> SimulSummary {
+        let u = s.host.value1
+        let extra = s.host.value2
+        let host = SimulHost(id: u.id, name: u.name, rating: extra.rating, online: extra.online)
+        let mappedVariants: [SimulVariant] = s.variants.map { v in
+          SimulVariant(key: v.key?.rawValue, name: v.name, icon: v.icon)
+        }
+        return SimulSummary(
+          id: s.id, name: s.name, fullName: s.fullName, host: host, variants: mappedVariants,
+          isCreated: s.isCreated, isRunning: s.isRunning, isFinished: s.isFinished, text: s.text,
+          estimatedStartAt: s.estimatedStartAt, startedAt: s.startedAt, finishedAt: s.finishedAt,
+          nbApplicants: s.nbApplicants, nbPairings: s.nbPairings)
+      }
+      return SimulsResponse(
+        created: (json.created ?? []).map(mapOne),
+        started: (json.started ?? []).map(mapOne),
+        finished: (json.finished ?? []).map(mapOne),
+        pending: (json.pending ?? []).map(mapOne)
+      )
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/SimulsTests.swift
+++ b/Tests/LichessClientTests/SimulsTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class SimulsTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) { try await handler(request, body, baseURL, operationID) }
+  }
+
+  func testGetSimulsMapsLists() async throws {
+    let json = """
+    {"created":[{"id":"s1","host":{"id":"h","name":"Host"},"name":"N","fullName":"FN","variants":[{"name":"Blitz"}],"isCreated":true,"isFinished":false,"isRunning":false,"nbApplicants":0,"nbPairings":0}],
+      "started":[],"finished":[],"pending":[]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiSimul")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.getSimuls()
+    XCTAssertEqual(res.created.first?.id, "s1")
+    XCTAssertEqual(res.created.first?.host.name, "Host")
+  }
+}
+


### PR DESCRIPTION
Summary

This PR adds public API coverage for the Simuls endpoint:

- `getSimuls()` → returns created/started/finished/pending lists with host + variants

Details

- New: `Sources/LichessClient/LichessClient+Simuls.swift` with public models and mapping
- Examples: `SimulsExample` target
- README: added “Simuls” usage section
- Tests: `SimulsTests` validate mapping

Notes

- Keeps generator types internal; wrapper exposes Swifty models.

closes #51