### PR TITLE
Events API coverage: streamIncomingEvents()

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,13 @@ for try await evt in Streaming.ndjsonStream(from: tvBody, as: Components.Schemas
   print(evt.id)
 }
 
+// Incoming events stream (NDJSON)
+let evBody = try await client.streamIncomingEvents()
+struct Incoming: Decodable { let type: String }
+for try await e in Streaming.ndjsonStream(from: evBody, as: Incoming.self) {
+  print(e.type); break
+}
+
 // TV channels and per-channel games
 let tv = try await client.getTVChannels()
 for (channel, game) in tv.entries { print(channel, game.user.name, game.rating) }

--- a/Sources/LichessClient/LichessClient+Events.swift
+++ b/Sources/LichessClient/LichessClient+Events.swift
@@ -1,0 +1,42 @@
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  public enum IncomingEvent: Codable, Sendable, Hashable {
+    case gameStart(Game)
+    case gameFinish(Game)
+    case challenge(Challenge)
+    case challengeCanceled(String?)
+    case challengeDeclined(String?)
+    case unknown(String)
+
+    public struct Game: Codable, Sendable, Hashable { public let id: String }
+    public struct Challenge: Codable, Sendable, Hashable { public let id: String; public let status: String? }
+  }
+
+  /// Open the incoming events stream as an NDJSON HTTPBody.
+  /// Use `Streaming.ndjsonStream` to decode incremental items.
+  public func streamIncomingEvents() async throws -> HTTPBody {
+    let resp = try await underlyingClient.apiStreamEvent()
+    switch resp {
+    case .ok(let ok):
+      return try ok.body.application_x_hyphen_ndjson
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Minimal decoder that maps generic event objects into `IncomingEvent`.
+  public static func decodeIncomingEvent(from data: Data) -> IncomingEvent? {
+    struct Raw: Decodable { let type: String?; let game: Game?; let challenge: Challenge?; struct Game: Decodable { let id: String? }; struct Challenge: Decodable { let id: String?; let status: String? } }
+    guard let raw = try? JSONDecoder().decode(Raw.self, from: data), let t = raw.type else { return nil }
+    switch t {
+    case "gameStart": return raw.game?.id.map { .gameStart(.init(id: $0)) } ?? .unknown(t)
+    case "gameFinish": return raw.game?.id.map { .gameFinish(.init(id: $0)) } ?? .unknown(t)
+    case "challenge": return raw.challenge?.id.map { .challenge(.init(id: $0, status: raw.challenge?.status)) } ?? .unknown(t)
+    case "challengeCanceled": return .challengeCanceled(raw.challenge?.id)
+    case "challengeDeclined": return .challengeDeclined(raw.challenge?.id)
+    default: return .unknown(t)
+    }
+  }
+}

--- a/Tests/LichessClientTests/EventsTests.swift
+++ b/Tests/LichessClientTests/EventsTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class EventsTests: XCTestCase {
+  func testDecodeIncomingEvent() throws {
+    let js1 = "{\"type\":\"gameStart\",\"game\":{\"id\":\"abcd\"}}"
+    let js2 = "{\"type\":\"challenge\",\"challenge\":{\"id\":\"xyz\",\"status\":\"created\"}}"
+    let e1 = LichessClient.decodeIncomingEvent(from: js1.data(using: .utf8)!)
+    if case let .gameStart(g)? = e1 { XCTAssertEqual(g.id, "abcd") } else { XCTFail("wrong type") }
+    let e2 = LichessClient.decodeIncomingEvent(from: js2.data(using: .utf8)!)
+    if case let .challenge(ch)? = e2 { XCTAssertEqual(ch.id, "xyz") } else { XCTFail("wrong type") }
+  }
+
+  func testStreamIncomingEventsReturnsNDJSON() async throws {
+    struct Transport: ClientTransport { let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?); func send(_ r: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) { try await handler(r, body, baseURL, operationID) } }
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiStreamEvent")
+      return (HTTPResponse(status: .ok), HTTPBody("{\"type\":\"gameStart\",\"game\":{\"id\":\"g1\"}}\n"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let body = try await client.streamIncomingEvents()
+    var got = false
+    for try await item in Streaming.ndjsonStream(from: body, as: DecodableEvent.self) {
+      XCTAssertEqual(item.type, "gameStart"); got = true; break
+    }
+    XCTAssertTrue(got)
+  }
+
+  struct DecodableEvent: Decodable { let type: String }
+}
+


### PR DESCRIPTION
Summary

This PR adds public API coverage for the Incoming Events stream:

- `streamIncomingEvents()` → returns NDJSON body for the logged-in user
- `decodeIncomingEvent(from:)` → optional helper to map raw lines to a small `IncomingEvent` enum

Details

- New: `Sources/LichessClient/LichessClient+Events.swift`
- README: NDJSON example for events
- Tests: `EventsTests` for decode and NDJSON streaming

Notes

- Wrapper surfaces raw `HTTPBody` to keep consumer flexibility.

closes #52