### PR TITLE
FIDE API coverage: getFIDEPlayer(id:) and searchFIDEPlayers(q:)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,3 +298,13 @@ let client = LichessClient()
 let simuls = try await client.getSimuls()
 print(simuls.created.count, simuls.started.count)
 ```
+## FIDE
+
+```swift
+let client = LichessClient()
+let fide = try await client.getFIDEPlayer(id: 750419)
+print(fide.name, fide.standard ?? -1)
+
+let matches = try await client.searchFIDEPlayers(query: "Carlsen")
+print(matches.prefix(3).map(\.name))
+```

--- a/Sources/LichessClient/LichessClient+FIDE.swift
+++ b/Sources/LichessClient/LichessClient+FIDE.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+extension LichessClient {
+  public struct FIDEPlayer: Codable, Sendable, Hashable {
+    public let id: Int
+    public let name: String
+    public let title: String?
+    public let federation: String?
+    public let year: Int?
+    public let inactive: Bool?
+    public let standard: Int?
+    public let rapid: Int?
+    public let blitz: Int?
+  }
+
+  private func mapFIDE(_ p: Components.Schemas.FIDEPlayer) -> FIDEPlayer {
+    FIDEPlayer(
+      id: p.id,
+      name: p.name,
+      title: p.title?.rawValue,
+      federation: p.federation,
+      year: p.year.map { Int($0) },
+      inactive: p.inactive.map { $0 != 0 },
+      standard: p.standard,
+      rapid: p.rapid,
+      blitz: p.blitz
+    )
+  }
+
+  /// Get a FIDE player by FIDE ID.
+  public func getFIDEPlayer(id: Int) async throws -> FIDEPlayer {
+    let resp = try await underlyingClient.fidePlayerGet(path: .init(playerId: Double(id)))
+    switch resp {
+    case .ok(let ok):
+      return mapFIDE(try ok.body.json)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Search FIDE players by name query.
+  public func searchFIDEPlayers(query: String) async throws -> [FIDEPlayer] {
+    let resp = try await underlyingClient.fidePlayerSearch(query: .init(q: query))
+    switch resp {
+    case .ok(let ok):
+      return try ok.body.json.map(mapFIDE)
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/FIDETests.swift
+++ b/Tests/LichessClientTests/FIDETests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class FIDETests: XCTestCase {
+  struct Transport: ClientTransport { let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?); func send(_ r: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) { try await handler(r, body, baseURL, operationID) } }
+
+  func testGetFIDEPlayerMapsFields() async throws {
+    let json = """
+    {"id":123,"name":"Alice","title":"IM","federation":"USA","year":1999,"inactive":0,"standard":2400,"rapid":2350,"blitz":2380}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "fidePlayerGet"); return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let p = try await client.getFIDEPlayer(id: 123)
+    XCTAssertEqual(p.name, "Alice"); XCTAssertEqual(p.title, "IM"); XCTAssertEqual(p.standard, 2400)
+  }
+
+  func testSearchFIDEPlayers() async throws {
+    let json = """
+    [{"id":1,"name":"A","federation":"USA"},{"id":2,"name":"B","federation":"NOR"}]
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "fidePlayerSearch"); return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.searchFIDEPlayers(query: "al")
+    XCTAssertEqual(res.count, 2)
+  }
+}


### PR DESCRIPTION
Summary

This PR adds public API coverage for FIDE endpoints:

- `getFIDEPlayer(id:)` → typed player info (federation, ratings, etc.)
- `searchFIDEPlayers(q:)` → list of players matching query

Details

- New: `Sources/LichessClient/LichessClient+FIDE.swift` + `FIDEPlayer` model
- Tests: `FIDETests` for both endpoints
- README: “FIDE” usage section

Notes

- Bridges generator types to stable public model, converting year (Double?) and inactive (Int?) to Int?/Bool?.

closes #53