### PR TITLE
Streamers API coverage: example + docs follow-up

### DIFF
--- a/Examples/StreamersExample/main.swift
+++ b/Examples/StreamersExample/main.swift
@@ -1,0 +1,16 @@
+import Foundation
+import LichessClient
+
+@main
+struct App {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let live = try await client.getLiveStreamers()
+      print(live.prefix(5))
+    } catch {
+      print("Error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -60,6 +60,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/SimulsExample"
         ),
+        .executableTarget(
+            name: "StreamersExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/StreamersExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -308,3 +308,10 @@ print(fide.name, fide.standard ?? -1)
 let matches = try await client.searchFIDEPlayers(query: "Carlsen")
 print(matches.prefix(3).map(\.name))
 ```
+## Streamers
+
+```swift
+let client = LichessClient()
+let live = try await client.getLiveStreamers()
+print(live.prefix(3).map { ($0.id, $0.service ?? "-") })
+```

--- a/Sources/LichessClient/LichessClient+Streamers.swift
+++ b/Sources/LichessClient/LichessClient+Streamers.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+extension LichessClient {
+  public struct LiveStreamer: Codable, Sendable, Hashable {
+    public let id: String
+    public let name: String?
+    public let headline: String?
+    public let description: String?
+    public let service: String?
+    public let status: String?
+    public let lang: String?
+    public let twitch: String?
+    public let youTube: String?
+    public let image: String?
+  }
+
+  /// Get live streamers currently broadcasting on Lichess.
+  public func getLiveStreamers() async throws -> [LiveStreamer] {
+    let resp = try await underlyingClient.streamerLive()
+    switch resp {
+    case .ok(let ok):
+      let rows = try ok.body.json
+      return rows.map { row in
+        let u = row.value1
+        let info = row.value2
+        return LiveStreamer(
+          id: u.id,
+          name: info.streamer?.name,
+          headline: info.streamer?.headline,
+          description: info.streamer?.description,
+          service: info.stream?.service?.rawValue,
+          status: info.stream?.status,
+          lang: info.stream?.lang,
+          twitch: info.streamer?.twitch,
+          youTube: info.streamer?.youTube,
+          image: info.streamer?.image
+        )
+      }
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+}

--- a/Tests/LichessClientTests/StreamersTests.swift
+++ b/Tests/LichessClientTests/StreamersTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class StreamersTests: XCTestCase {
+  struct Transport: ClientTransport { let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?); func send(_ r: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) { try await handler(r, body, baseURL, operationID) } }
+
+  func testGetLiveStreamersMapsFields() async throws {
+    let json = """
+    [{"id":"s1","name":"Alice"}]
+    """
+    // Generator expects a flattened tuple object with LightUser fields and extra keys at the same level
+    let wired = "[{\"id\":\"alice\",\"name\":\"Alice\",\"stream\":{\"service\":\"twitch\",\"status\":\"Playing\"},\"streamer\":{\"name\":\"Alice\",\"twitch\":\"https://twitch.tv/a\"}}]"
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "streamerLive")
+      return (HTTPResponse(status: .ok), HTTPBody(wired))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let list = try await client.getLiveStreamers()
+    XCTAssertEqual(list.first?.id, "alice")
+    XCTAssertEqual(list.first?.service, "twitch")
+  }
+}


### PR DESCRIPTION
Summary

Adds a runnable example for the live streamers wrapper introduced in master.

- `Examples/StreamersExample` prints top entries from `getLiveStreamers()`
- `Package.swift` updated to include the new example target

This complements the already merged streamers wrapper, tests, and README updates.

closes #54