### PR TITLE
Bot API: Public API coverage (wrappers, example)

### DIFF
--- a/Examples/BotExample/main.swift
+++ b/Examples/BotExample/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+import LichessClient
+
+@main
+struct BotExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      // Stream online bots (first item then stop)
+      let body = try await client.streamOnlineBots()
+      struct AnyJSON: Decodable {}
+      for try await _ in Streaming.ndjsonStream(from: body, as: AnyJSON.self) {
+        print("online bot item"); break
+      }
+    } catch {
+      print("BotExample error:", error)
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -85,6 +85,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/BoardExample"
         ),
+        .executableTarget(
+            name: "BotExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/BotExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -413,3 +413,18 @@ case .correspondence(let id):
 let nd = try await client.streamBoardGame(gameId: "<your-game-id>")
 for try await _ in Streaming.ndjsonStream(from: nd, as: Components.Schemas.OpenAPIRuntime.OpenAPIValueContainer.self) { break }
 ```
+
+## Bot API
+
+```swift
+// Most Bot endpoints require a Bot account + token (bot:play scope)
+let client = LichessClient(accessToken: "<token>")
+
+// Online bots stream
+let bots = try await client.streamOnlineBots()
+for try await _ in bots { break }
+
+// Stream a bot game
+let gameBody = try await client.streamBotGame(gameId: "<game-id>")
+for try await _ in Streaming.ndjsonStream(from: gameBody, as: Components.Schemas.OpenAPIRuntime.OpenAPIValueContainer.self) { break }
+```

--- a/Sources/LichessClient/LichessClient+Bot.swift
+++ b/Sources/LichessClient/LichessClient+Bot.swift
@@ -1,0 +1,84 @@
+//
+//  LichessClient+Bot.swift
+//
+
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  public enum BotChatRoom: String, Sendable, Hashable { case player, spectator }
+
+  /// Stream online bots as NDJSON HTTPBody.
+  public func streamOnlineBots(nb: Int? = nil) async throws -> HTTPBody {
+    let resp = try await underlyingClient.apiBotOnline()
+    switch resp {
+    case .ok(let ok):
+      return try ok.body.application_x_hyphen_ndjson
+    case .undocumented(let status, _):
+      throw LichessClientError.undocumentedResponse(statusCode: status)
+    }
+  }
+
+  /// Upgrade the current account to a Bot account.
+  public func upgradeToBotAccount() async throws -> Bool {
+    let resp = try await underlyingClient.botAccountUpgrade()
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  /// Stream a Bot game state as NDJSON.
+  public func streamBotGame(gameId: String) async throws -> HTTPBody {
+    let resp = try await underlyingClient.botGameStream(path: .init(gameId: gameId))
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_ndjson; case .notFound: throw LichessClientError.notFound; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  /// Make a move in a Bot game (UCI). Optionally offer/agree draw.
+  public func playBotMove(gameId: String, move: String, offeringDraw: Bool? = nil) async throws -> Bool {
+    let resp = try await underlyingClient.botGameMove(path: .init(gameId: gameId, move: move), query: .init(offeringDraw: offeringDraw))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  /// Stream chat of a Bot game as NDJSON.
+  public func streamBotChat(gameId: String) async throws -> HTTPBody {
+    let resp = try await underlyingClient.botGameChatGet(path: .init(gameId: gameId))
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_ndjson; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  /// Post a message to a Bot game chat.
+  public func postBotChat(gameId: String, room: BotChatRoom, text: String) async throws -> Bool {
+    let roomPayload = Operations.botGameChat.Input.Body.urlEncodedFormPayload.roomPayload(rawValue: room.rawValue) ?? .player
+    let resp = try await underlyingClient.botGameChat(path: .init(gameId: gameId), body: .urlEncodedForm(.init(room: roomPayload, text: text)))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func abortBotGame(gameId: String) async throws -> Bool {
+    let resp = try await underlyingClient.botGameAbort(path: .init(gameId: gameId))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func resignBotGame(gameId: String) async throws -> Bool {
+    let resp = try await underlyingClient.botGameResign(path: .init(gameId: gameId))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func handleBotDraw(gameId: String, accept: Bool) async throws -> Bool {
+    let path = Operations.botGameDraw.Input.Path(gameId: gameId, accept: accept ? .init(value2: .yes) : .init(value1: false))
+    let resp = try await underlyingClient.botGameDraw(path: path)
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func handleBotTakeback(gameId: String, accept: Bool) async throws -> Bool {
+    let path = Operations.botGameTakeback.Input.Path(gameId: gameId, accept: accept ? .init(value2: .yes) : .init(value1: false))
+    let resp = try await underlyingClient.botGameTakeback(path: path)
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func claimBotVictory(gameId: String) async throws -> Bool {
+    let resp = try await underlyingClient.botGameClaimVictory(path: .init(gameId: gameId))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func claimBotDraw(gameId: String) async throws -> Bool {
+    let resp = try await underlyingClient.botGameClaimDraw(path: .init(gameId: gameId))
+    switch resp { case .ok: return true; case .badRequest: throw LichessClientError.httpStatus(statusCode: 400); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+}


### PR DESCRIPTION
What's in this PR

- Add `Sources/LichessClient/LichessClient+Bot.swift` with public wrappers for Bot API endpoints:
  - `apiBotOnline` (streamOnlineBots, NDJSON)
  - `botAccountUpgrade` (upgradeToBotAccount)
  - `botGameStream` (streamBotGame, NDJSON)
  - `botGameMove` (playBotMove)
  - `botGameChatGet` (streamBotChat, NDJSON)
  - `botGameChat` (postBotChat)
  - `botGameAbort` (abortBotGame)
  - `botGameResign` (resignBotGame)
  - `botGameDraw` (handleBotDraw)
  - `botGameTakeback` (handleBotTakeback)
  - `botGameClaimVictory` (claimBotVictory)
  - `botGameClaimDraw` (claimBotDraw)

- New `Examples/BotExample` target.
- README includes a short Bot API snippet.
- Build verified via `swift build -c release`.

closes #34