### PR TITLE
Game Export/Import: public API coverage + example

### DIFF
--- a/Examples/GameExportExample/main.swift
+++ b/Examples/GameExportExample/main.swift
@@ -1,0 +1,18 @@
+import Foundation
+import LichessClient
+
+@main
+struct GameExportExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let body = try await client.exportUserGames(username: "thibault", format: .pgn, max: 5, moves: true)
+      var count = 0
+      for try await _ in body { count += 1 }
+      print("Exported entries stream chunks: \(count)")
+    } catch {
+      print("GameExportExample error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -100,6 +100,11 @@ let package = Package(
             dependencies: ["LichessClient"],
             path: "Examples/BroadcastsExample"
         ),
+        .executableTarget(
+            name: "GameExportExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/GameExportExample"
+        ),
         .testTarget(
             name: "LichessClientTests",
             dependencies: ["LichessClient"]),

--- a/README.md
+++ b/README.md
@@ -155,6 +155,30 @@ let next = try await client.getNextPuzzle(angle: "mateIn2")
 print(next.puzzle.id)
 ```
 
+## Game Export / Import
+
+```swift
+import LichessClient
+
+let client = LichessClient()
+
+// Export one game as PGN
+let pgn = try await client.exportGame(id: "abcdefgh", format: .pgn)
+for try await _ in pgn { break }
+
+// Export recent games of a user (PGN or NDJSON)
+let userGames = try await client.exportUserGames(username: "thibault", format: .pgn, max: 10)
+for try await _ in userGames { /* consume */ }
+
+// Export specific games by IDs (NDJSON)
+let idsBody = try await client.exportGamesByIds(ids: ["abcdefgh", "ijklmnop"], format: .ndjson, moves: true)
+for try await _ in idsBody { break }
+
+// Import a PGN as a new game
+let res = try await client.importGame(pgn: "[Event \"Casual\"]\n1. e4 e5 *")
+print(res.id, res.url)
+```
+
 ## Crosstable
 
 ```swift

--- a/Sources/LichessClient/LichessClient+GameExport.swift
+++ b/Sources/LichessClient/LichessClient+GameExport.swift
@@ -1,0 +1,228 @@
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  // MARK: - Types
+
+  public enum GameSingleFormat { case pgn, json }
+
+  public struct GameJSON: Codable, Sendable {
+    public let id: String
+    public let moves: String?
+  }
+
+  public struct GameImportResult: Codable, Sendable { public let id: String?; public let url: String? }
+
+  // MARK: - Single game export
+
+  /// Export one game (PGN or JSON).
+  public func exportGame(
+    id: String,
+    format: GameSingleFormat = .pgn,
+    moves: Bool? = nil,
+    pgnInJson: Bool? = nil,
+    tags: Bool? = nil,
+    clocks: Bool? = nil,
+    evals: Bool? = nil,
+    accuracy: Bool? = nil,
+    opening: Bool? = nil,
+    division: Bool? = nil,
+    literate: Bool? = nil,
+    withBookmarked: Bool? = nil
+  ) async throws -> HTTPBody {
+    let accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.gamePgn.AcceptableContentType>] = {
+      switch format {
+      case .pgn: return [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)]
+      case .json: return [.init(contentType: .json)]
+      }
+    }()
+    let resp = try await underlyingClient.gamePgn(
+      path: .init(gameId: id),
+      query: .init(moves: moves, pgnInJson: pgnInJson, tags: tags, clocks: clocks, evals: evals, accuracy: accuracy, opening: opening, division: division, literate: literate, withBookmarked: withBookmarked),
+      headers: .init(accept: accept)
+    )
+    switch resp { case .ok(let ok): return try ok.body.asHTTPBody(); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  // MARK: - User games export (PGN or NDJSON)
+
+  public func exportUserGames(
+    username: String,
+    format: ExportFormat = .pgn,
+    since: Int? = nil,
+    until: Int? = nil,
+    max: Int? = nil,
+    vs: String? = nil,
+    rated: Bool? = nil,
+    color: String? = nil,
+    analysed: Bool? = nil,
+    moves: Bool? = nil,
+    pgnInJson: Bool? = nil,
+    tags: Bool? = nil,
+    clocks: Bool? = nil,
+    evals: Bool? = nil,
+    accuracy: Bool? = nil,
+    opening: Bool? = nil,
+    division: Bool? = nil,
+    ongoing: Bool? = nil,
+    finished: Bool? = nil,
+    literate: Bool? = nil,
+    lastFen: Bool? = nil,
+    withBookmarked: Bool? = nil,
+    sort: String? = nil
+  ) async throws -> HTTPBody {
+    let accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.apiGamesUser.AcceptableContentType>] =
+      format == .pgn ? [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)] : [.init(contentType: .application_x_hyphen_ndjson)]
+    let resp = try await underlyingClient.apiGamesUser(
+      path: .init(username: username),
+      query: .init(
+        since: since, until: until, max: max, vs: vs, rated: rated,
+        perfType: nil,
+        color: color.flatMap { Operations.apiGamesUser.Input.Query.colorPayload(rawValue: $0) },
+        analysed: analysed, moves: moves, pgnInJson: pgnInJson, tags: tags, clocks: clocks, evals: evals,
+        accuracy: accuracy, opening: opening, division: division, ongoing: ongoing, finished: finished,
+        literate: literate, lastFen: lastFen, withBookmarked: withBookmarked,
+        sort: sort.flatMap { Operations.apiGamesUser.Input.Query.sortPayload(rawValue: $0) }
+      ),
+      headers: .init(accept: accept)
+    )
+    switch resp { case .ok(let ok): return try ok.body.asHTTPBody(); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  // MARK: - Export games by IDs (PGN/NDJSON)
+
+  public func exportGamesByIds(
+    ids: [String],
+    format: ExportFormat = .pgn,
+    moves: Bool? = nil,
+    pgnInJson: Bool? = nil,
+    tags: Bool? = nil,
+    clocks: Bool? = nil,
+    evals: Bool? = nil,
+    accuracy: Bool? = nil,
+    opening: Bool? = nil,
+    division: Bool? = nil,
+    literate: Bool? = nil
+  ) async throws -> HTTPBody {
+    let accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.gamesExportIds.AcceptableContentType>] =
+      format == .pgn ? [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)] : [.init(contentType: .application_x_hyphen_ndjson)]
+    let bodyText = ids.joined(separator: "\n")
+    let resp = try await underlyingClient.gamesExportIds(
+      query: .init(moves: moves, pgnInJson: pgnInJson, tags: tags, clocks: clocks, evals: evals, accuracy: accuracy, opening: opening, division: division, literate: literate),
+      headers: .init(accept: accept),
+      body: .plainText(.init(bodyText))
+    )
+    switch resp { case .ok(let ok): return try ok.body.asHTTPBody(); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  // MARK: - Streaming by users / ids
+
+  public func streamGamesByUsers(usernames: [String], withCurrentGames: Bool? = nil) async throws -> HTTPBody {
+    let bodyText = usernames.joined(separator: "\n")
+    let resp = try await underlyingClient.gamesByUsers(
+      query: .init(withCurrentGames: withCurrentGames),
+      headers: .init(),
+      body: .plainText(.init(bodyText))
+    )
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_ndjson; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func streamGamesByIds(streamId: String, ids: [String]) async throws -> HTTPBody {
+    let resp = try await underlyingClient.gamesByIds(
+      path: .init(streamId: streamId),
+      headers: .init(),
+      body: .plainText(.init(ids.joined(separator: "\n")))
+    )
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_ndjson; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func addGamesToStream(streamId: String, ids: [String]) async throws -> Bool {
+    let resp = try await underlyingClient.gamesByIdsAdd(
+      path: .init(streamId: streamId),
+      headers: .init(),
+      body: .plainText(.init(ids.joined(separator: "\n")))
+    )
+    switch resp { case .ok: return true; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  // MARK: - Import / My imports / Bookmarks
+
+  public func importGame(pgn: String) async throws -> GameImportResult {
+    let resp = try await underlyingClient.gameImport(body: .urlEncodedForm(.init(pgn: pgn)))
+    switch resp {
+    case .ok(let ok):
+      let payload = try ok.body.json
+      return GameImportResult(id: payload.id, url: payload.url)
+    case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
+
+  public func exportMyImportedGames() async throws -> HTTPBody {
+    let resp = try await underlyingClient.apiImportedGamesUser()
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_chess_hyphen_pgn; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func exportBookmarkedGames(
+    format: ExportFormat = .pgn,
+    since: Int? = nil,
+    until: Int? = nil,
+    max: Int? = nil,
+    moves: Bool? = nil,
+    pgnInJson: Bool? = nil,
+    tags: Bool? = nil,
+    clocks: Bool? = nil,
+    evals: Bool? = nil,
+    accuracy: Bool? = nil,
+    opening: Bool? = nil,
+    division: Bool? = nil,
+    literate: Bool? = nil,
+    lastFen: Bool? = nil,
+    sort: String? = nil
+  ) async throws -> HTTPBody {
+    let accept: [OpenAPIRuntime.AcceptHeaderContentType<Operations.apiExportBookmarks.AcceptableContentType>] =
+      format == .pgn ? [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)] : [.init(contentType: .application_x_hyphen_ndjson)]
+    let resp = try await underlyingClient.apiExportBookmarks(
+      query: .init(since: since, until: until, max: max, moves: moves, pgnInJson: pgnInJson, tags: tags, clocks: clocks, evals: evals, accuracy: accuracy, opening: opening, division: division, literate: literate, lastFen: lastFen, sort: sort.flatMap { Operations.apiExportBookmarks.Input.Query.sortPayload(rawValue: $0) }),
+      headers: .init(accept: accept)
+    )
+    switch resp { case .ok(let ok): return try ok.body.asHTTPBody(); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+}
+
+private extension Operations.gamePgn.Output.Ok.Body {
+  func asHTTPBody() throws -> HTTPBody {
+    switch self {
+    case .application_x_hyphen_chess_hyphen_pgn(let b): return b
+    case .json(let j):
+      let data = try JSONEncoder().encode(j)
+      return HTTPBody(data)
+    }
+  }
+}
+
+private extension Operations.apiGamesUser.Output.Ok.Body {
+  func asHTTPBody() throws -> HTTPBody {
+    switch self {
+    case .application_x_hyphen_chess_hyphen_pgn(let b): return b
+    case .application_x_hyphen_ndjson(let b): return b
+    }
+  }
+}
+
+private extension Operations.gamesExportIds.Output.Ok.Body {
+  func asHTTPBody() throws -> HTTPBody {
+    switch self {
+    case .application_x_hyphen_chess_hyphen_pgn(let b): return b
+    case .application_x_hyphen_ndjson(let b): return b
+    }
+  }
+}
+
+private extension Operations.apiExportBookmarks.Output.Ok.Body {
+  func asHTTPBody() throws -> HTTPBody {
+    switch self {
+    case .application_x_hyphen_chess_hyphen_pgn(let b): return b
+    case .application_x_hyphen_ndjson(let b): return b
+    }
+  }
+}


### PR DESCRIPTION
Summary

Adds public wrappers for Game Export/Import endpoints, a minimal example, and README snippet. Covers export of single games, user games, games by IDs, streaming by users/IDs, importing PGN, and exporting bookmarks/imported games.

Implemented wrappers

- exportGame(id:format:...) (PGN or JSON)
- exportUserGames(username:format:...) (PGN or NDJSON)
- exportGamesByIds(ids:format:...) (PGN or NDJSON)
- streamGamesByUsers(usernames:withCurrentGames:) (NDJSON)
- streamGamesByIds(streamId:ids:) (NDJSON)
- addGamesToStream(streamId:ids:)
- importGame(pgn:)
- exportMyImportedGames() (PGN)
- exportBookmarkedGames(format:...) (PGN or NDJSON)

Docs & example

- New example at `Examples/GameExportExample`
- README updated with usage snippet

Build

- `swift build` succeeds locally

closes #36