### PR TITLE
feat(opening-explorer): Masters game PGN wrapper, example, and tests

### DIFF
--- a/Examples/OpeningExplorerExample/main.swift
+++ b/Examples/OpeningExplorerExample/main.swift
@@ -1,0 +1,32 @@
+import Foundation
+import LichessClient
+
+@main
+struct OpeningExplorerExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      // Masters DB lookup
+      let masters = try await client.getOpeningExplorerMasters(
+        fen: "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1",
+        moves: 5,
+        topGames: 1
+      )
+      print("Masters moves:", masters.moves.prefix(3).map(\.san))
+
+      // Fetch PGN of a masters game (replace with a real game id)
+      let pgnBody = try await client.getOpeningExplorerMastersGamePGN(gameId: "<masters-game-id>")
+      var printedFirstLine = false
+      for try await chunk in pgnBody {
+        if !printedFirstLine {
+          print(String(decoding: chunk, as: UTF8.self).split(separator: "\n").first ?? "-")
+          printedFirstLine = true
+        }
+        break
+      }
+    } catch {
+      print("OpeningExplorerExample error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,11 @@ let package = Package(
             path: "Examples/TVChannelsExample"
         ),
         .executableTarget(
+            name: "OpeningExplorerExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/OpeningExplorerExample"
+        ),
+        .executableTarget(
             name: "PlayersExample",
             dependencies: ["LichessClient"],
             path: "Examples/PlayersExample"

--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ let playerBody = try await client.streamOpeningExplorerPlayer(
 for try await item in Streaming.ndjsonStream(from: playerBody, as: Components.Schemas.OpeningExplorerPlayer.self) {
   print(item)
 }
+// Fetch PGN of a Masters game by id
+let mastersPGN = try await client.getOpeningExplorerMastersGamePGN(gameId: "<game-id>")
+for try await _ in mastersPGN { break }
 ```
 
 ## Tournaments & Swiss

--- a/Sources/LichessClient/LichessClient+OpeningExplorer.swift
+++ b/Sources/LichessClient/LichessClient+OpeningExplorer.swift
@@ -244,4 +244,21 @@ extension LichessClient {
       throw LichessClientError.undocumentedResponse(statusCode: statusCode)
     }
   }
+
+  // MARK: Masters game PGN
+  /// Fetch the PGN of a Masters database game by its ID.
+  /// - Parameter gameId: Masters game identifier returned by explorer endpoints.
+  /// - Returns: The PGN payload as `HTTPBody`.
+  public func getOpeningExplorerMastersGamePGN(gameId: String) async throws -> HTTPBody {
+    let resp = try await underlyingClient.openingExplorerMasterGame(
+      path: .init(gameId: gameId),
+      headers: .init(accept: [.init(contentType: .application_x_hyphen_chess_hyphen_pgn)])
+    )
+    switch resp {
+    case .ok(let ok):
+      return try ok.body.application_x_hyphen_chess_hyphen_pgn
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
 }

--- a/Tests/LichessClientTests/OpeningExplorerTests.swift
+++ b/Tests/LichessClientTests/OpeningExplorerTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class OpeningExplorerTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testMastersGameAcceptHeaderAndBody() async throws {
+    var seenAccept: String?
+    let transport = Transport { req, _, _, op in
+      XCTAssertEqual(op, "openingExplorerMasterGame")
+      seenAccept = req.headerFields[.accept]
+      return (HTTPResponse(status: .ok), HTTPBody("[Event \"X\"]\n*\n"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let body = try await client.getOpeningExplorerMastersGamePGN(gameId: "abc")
+    var gotLine = false
+    for try await chunk in body {
+      let line = String(decoding: chunk, as: UTF8.self)
+      XCTAssertTrue(line.contains("[Event"))
+      gotLine = true
+      break
+    }
+    XCTAssertTrue(gotLine)
+    XCTAssertTrue(seenAccept?.contains("application/x-chess-pgn") ?? false)
+  }
+}
+


### PR DESCRIPTION
This PR adds coverage for the remaining Opening Explorer endpoint:

- Public wrapper: `getOpeningExplorerMastersGamePGN(gameId:)`
- Accept header set to `application/x-chess-pgn`; returns `HTTPBody`
- New example target: `OpeningExplorerExample`
- Tests: verify Accept header and first PGN line is surfaced
- README: added short snippet under Opening Explorer

All tests pass (`swift test`).

Closes #41