### PR TITLE
feat(users): player autocomplete wrapper, example, and tests

### DIFF
--- a/Examples/AutocompleteExample/main.swift
+++ b/Examples/AutocompleteExample/main.swift
@@ -1,0 +1,21 @@
+import Foundation
+import LichessClient
+
+@main
+struct AutocompleteExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      let result = try await client.autocompletePlayers(term: "magn", object: true)
+      switch result {
+      case .usernames(let names):
+        print(names.prefix(3))
+      case .users(let users):
+        print(users.prefix(3).map { "\($0.name)\($0.online == true ? " (online)" : "")" })
+      }
+    } catch {
+      print("Autocomplete error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,11 @@ let package = Package(
             path: "Examples/TVChannelsExample"
         ),
         .executableTarget(
+            name: "AutocompleteExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/AutocompleteExample"
+        ),
+        .executableTarget(
             name: "OpeningExplorerExample",
             dependencies: ["LichessClient"],
             path: "Examples/OpeningExplorerExample"

--- a/README.md
+++ b/README.md
@@ -65,6 +65,21 @@ let me = try await client.getMyProfile()
 let email = try await client.getMyEmail()
 ```
 
+### Autocomplete
+
+```swift
+let client = LichessClient()
+
+// Get usernames or user objects matching a prefix
+let ac = try await client.autocompletePlayers(term: "magn", object: true)
+switch ac {
+case .usernames(let names):
+  print(names.prefix(5))
+case .users(let users):
+  print(users.prefix(5).map(\.name))
+}
+```
+
 ## Account
 
 ```swift

--- a/Sources/LichessClient/LichessClient+Users.swift
+++ b/Sources/LichessClient/LichessClient+Users.swift
@@ -1,6 +1,53 @@
 import Foundation
 
 extension LichessClient {
+  // MARK: - Autocomplete
+  public enum AutocompleteResult: Sendable, Hashable { case usernames([String]); case users([AutocompleteUser]) }
+
+  public struct AutocompleteUser: Sendable, Hashable {
+    public let id: String
+    public let name: String
+    public let title: String?
+    public let patron: Bool?
+    public let flair: String?
+    public let online: Bool?
+  }
+
+  public func autocompletePlayers(
+    term: String,
+    object: Bool? = nil,
+    names: Bool? = nil,
+    friend: Bool? = nil,
+    team: String? = nil,
+    tour: String? = nil,
+    swiss: String? = nil
+  ) async throws -> AutocompleteResult {
+    let resp = try await underlyingClient.apiPlayerAutocomplete(
+      query: .init(term: term, object: object, names: names, friend: friend, team: team, tour: tour, swiss: swiss)
+    )
+    switch resp {
+    case .ok(let ok):
+      switch try ok.body.json {
+      case .case1(let names):
+        return .usernames(names)
+      case .case2(let payload):
+        let users: [AutocompleteUser] = (payload.result ?? []).map { lu in
+          let u = lu.value1
+          return AutocompleteUser(
+            id: u.id,
+            name: u.name,
+            title: u.title?.rawValue,
+            patron: u.patron,
+            flair: u.flair,
+            online: lu.value2.online
+          )
+        }
+        return .users(users)
+      }
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
   public struct PublicUser: Sendable, Hashable {
     public let id: String
     public let username: String
@@ -71,4 +118,3 @@ extension LichessClient {
     }
   }
 }
-

--- a/Tests/LichessClientTests/AutocompleteTests.swift
+++ b/Tests/LichessClientTests/AutocompleteTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class AutocompleteTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testAutocompleteReturnsUsernamesList() async throws {
+    let json = "[\"navan\",\"navanchauhan\"]"
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiPlayerAutocomplete")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.autocompletePlayers(term: "nav")
+    switch res {
+    case .usernames(let names):
+      XCTAssertTrue(names.contains("navan"))
+    default:
+      XCTFail("Expected usernames variant")
+    }
+  }
+
+  func testAutocompleteReturnsUsersObject() async throws {
+    let json = """
+    {"result":[{"id":"u1","name":"Alice","title":"WGM","patron":true,"online":true}]}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiPlayerAutocomplete")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let res = try await client.autocompletePlayers(term: "a", object: true)
+    switch res {
+    case .users(let users):
+      XCTAssertEqual(users.first?.name, "Alice")
+      XCTAssertEqual(users.first?.title, "WGM")
+      XCTAssertEqual(users.first?.online, true)
+    default:
+      XCTFail("Expected users variant")
+    }
+  }
+}
+


### PR DESCRIPTION
This PR completes the remaining "Other" coverage by adding a typed wrapper for the player autocomplete endpoint.

- Public wrapper: `autocompletePlayers(term:object:names:friend:team:tour:swiss:)` returning either usernames or typed users
- Example target: `AutocompleteExample`
- Tests: both list and object variants
- README: Users section adds a short snippet

All tests pass (`swift test`).

Closes #59