### PR TITLE
test(swiss): scheduleNextRound success path

### DIFF
--- a/Tests/LichessClientTests/SwissScheduleTests.swift
+++ b/Tests/LichessClientTests/SwissScheduleTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class SwissScheduleTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testScheduleNextRoundReturnsTrueOn204() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiSwissScheduleNextRound")
+      return (HTTPResponse(status: .noContent), nil)
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let ok = try await client.scheduleNextSwissRound(id: "sw1", dateMS: 1712345678901)
+    XCTAssertTrue(ok)
+  }
+}
+


### PR DESCRIPTION
Adds a unit test to exercise `scheduleNextSwissRound(id:dateMS:)` returning true on HTTP 204.

This complements the Swiss coverage implemented earlier and ties off the tracking issue.

All tests pass (`swift test`).

Closes #42