### PR TITLE
docs(oauth): add OAuth example target

### DIFF
--- a/Examples/OAuthExample/main.swift
+++ b/Examples/OAuthExample/main.swift
@@ -1,0 +1,21 @@
+import Foundation
+import LichessClient
+
+@main
+struct OAuthExample {
+  static func main() async {
+    let client = LichessClient()
+    let pkce = LichessClient.generatePKCE()
+    let state = UUID().uuidString
+    let redirect = URL(string: "myapp://callback")!
+    let url = client.buildAuthorizationURL(
+      clientID: "myapp",
+      redirectURI: redirect,
+      scopes: ["challenge:write", "email:read"],
+      state: state,
+      pkce: pkce
+    )
+    print(url.absoluteString)
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,11 @@ let package = Package(
             path: "Examples/TVChannelsExample"
         ),
         .executableTarget(
+            name: "OAuthExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/OAuthExample"
+        ),
+        .executableTarget(
             name: "AutocompleteExample",
             dependencies: ["LichessClient"],
             path: "Examples/AutocompleteExample"


### PR DESCRIPTION
Adds a minimal OAuthExample that builds the authorization URL using PKCE and prints it.

This completes the OAuth coverage tracked in #57 and complements the existing README snippet and tests.

Closes #57