### PR TITLE
feat(admin): admin challenge tokens wrapper, example, and tests

### DIFF
--- a/Examples/AdminExample/main.swift
+++ b/Examples/AdminExample/main.swift
@@ -1,0 +1,17 @@
+import Foundation
+import LichessClient
+
+@main
+struct AdminExample {
+  static func main() async {
+    // Requires an authenticated client with admin privileges.
+    let client = LichessClient(accessToken: "<admin_token>")
+    do {
+      let tokens = try await client.adminCreateChallengeTokens(usernames: ["alice","bob"], description: "Bulk pairing tokens")
+      print(tokens)
+    } catch {
+      print("AdminExample error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,11 @@ let package = Package(
             path: "Examples/TVChannelsExample"
         ),
         .executableTarget(
+            name: "AdminExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/AdminExample"
+        ),
+        .executableTarget(
             name: "OAuthExample",
             dependencies: ["LichessClient"],
             path: "Examples/OAuthExample"

--- a/README.md
+++ b/README.md
@@ -462,6 +462,15 @@ if let first = bulks.first {
 }
 ```
 
+### Admin (Challenge Tokens)
+
+```swift
+// Admin-only: create or reuse challenge:write tokens for users
+let admin = LichessClient(accessToken: "<admin_token>")
+let map = try await admin.adminCreateChallengeTokens(usernames: ["alice","bob"], description: "Bulk pairing")
+print(map["alice"] ?? "-")
+```
+
 ## External Engine
 
 ```swift

--- a/Sources/LichessClient/LichessClient+Admin.swift
+++ b/Sources/LichessClient/LichessClient+Admin.swift
@@ -1,0 +1,26 @@
+import Foundation
+import OpenAPIRuntime
+
+extension LichessClient {
+  // MARK: - Admin
+  /// Create or reuse `challenge:write` tokens for a list of usernames.
+  /// Note: This endpoint is restricted to Lichess administrators.
+  public func adminCreateChallengeTokens(usernames: [String], description: String) async throws -> [String: String] {
+    let users = usernames.joined(separator: ",")
+    let body = Operations.adminChallengeTokens.Input.Body.urlEncodedForm(.init(users: users, description: description))
+    let resp = try await underlyingClient.adminChallengeTokens(body: body)
+    switch resp {
+    case .ok(let ok):
+      let map = try ok.body.json.additionalProperties
+      return map
+    case .badRequest(let bad):
+      if case let .json(err) = bad.body {
+        throw LichessClientError.parsingError(error: NSError(domain: "AdminChallengeTokens", code: 400, userInfo: [NSLocalizedDescriptionKey: err.error ?? "Bad Request"]))
+      }
+      throw LichessClientError.httpStatus(statusCode: 400)
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
+}
+

--- a/Tests/LichessClientTests/AdminTests.swift
+++ b/Tests/LichessClientTests/AdminTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class AdminTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testAdminChallengeTokensFormAndMapping() async throws {
+    var capturedBody: String = ""
+    let transport = Transport { req, body, _, op in
+      XCTAssertEqual(op, "adminChallengeTokens")
+      XCTAssertEqual(req.method, .post)
+      XCTAssertEqual(req.headerFields[.contentType], "application/x-www-form-urlencoded")
+      if let body = body { capturedBody = try await String(collecting: body, upTo: 2048) }
+      let json = "{\"alice\":\"tok1\",\"bob\":\"tok2\"}"
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let map = try await client.adminCreateChallengeTokens(usernames: ["alice","bob"], description: "Bulk pairing")
+    XCTAssertTrue(capturedBody.contains("users=alice%2Cbob"))
+    XCTAssertTrue(capturedBody.contains("description=Bulk+pairing"))
+    XCTAssertEqual(map["alice"], "tok1")
+    XCTAssertEqual(map["bob"], "tok2")
+  }
+}
+


### PR DESCRIPTION
This PR adds public coverage for the Admin endpoint:

- `adminCreateChallengeTokens(usernames:description:)` → maps usernames to `challenge:write` tokens
- Example target: `AdminExample`
- Tests: verify form encoding and response mapping
- README: add brief snippet under Bulk Pairing

All tests pass (`swift test`).

Closes #58