### PR TITLE
feat(studies): delete chapter + last-modified HEAD; example and tests

### DIFF
--- a/Examples/StudiesExample/main.swift
+++ b/Examples/StudiesExample/main.swift
@@ -1,0 +1,20 @@
+import Foundation
+import LichessClient
+
+@main
+struct StudiesExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      // Check last-modified of full study PGN
+      if let lm = try await client.getStudyPGNLastModified(studyId: "lXnKRxIP") {
+        print("Last-Modified:", lm)
+      }
+      // Delete a chapter (requires permissions on the study)
+      _ = try? await client.deleteStudyChapter(studyId: "<study>", chapterId: "<chapter>")
+    } catch {
+      print("StudiesExample error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,11 @@ let package = Package(
             path: "Examples/TVChannelsExample"
         ),
         .executableTarget(
+            name: "StudiesExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/StudiesExample"
+        ),
+        .executableTarget(
             name: "AdminExample",
             dependencies: ["LichessClient"],
             path: "Examples/AdminExample"

--- a/README.md
+++ b/README.md
@@ -363,6 +363,11 @@ let raw = "[Event \"A\"]\n\n1. e4 e5 *\n\n\n[Event \"B\"]\n\n1. d4 d5 *"
 let sanitized = PGNUtilities.sanitizeForImport(raw)
 let importResult = try await client.importPGNIntoStudy(studyId: "lXnKRxIP", pgn: sanitized)
 print(importResult.chapters.map { $0?.name ?? "-" })
+// Delete a chapter (requires permission)
+_ = try? await client.deleteStudyChapter(studyId: "lXnKRxIP", chapterId: "JT3RkEwv")
+// HEAD for last-modified of full PGN
+let lastMod = try await client.getStudyPGNLastModified(studyId: "lXnKRxIP")
+print(lastMod?.description ?? "-")
 ```
 
 ## Cloud Evaluation

--- a/Tests/LichessClientTests/StudiesExtraTests.swift
+++ b/Tests/LichessClientTests/StudiesExtraTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class StudiesExtraTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) {
+      try await handler(request, body, baseURL, operationID)
+    }
+  }
+
+  func testDeleteStudyChapter204() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiStudyStudyIdChapterIdDelete")
+      return (HTTPResponse(status: .noContent), nil)
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let ok = try await client.deleteStudyChapter(studyId: "S", chapterId: "C")
+    XCTAssertTrue(ok)
+  }
+
+  func testStudyLastModifiedParsesDate() async throws {
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "studyAllChaptersHead")
+      var resp = HTTPResponse(status: .noContent)
+      resp.headerFields[HTTPField.Name("Last-Modified")!] = "Wed, 21 Oct 2015 07:28:00 GMT"
+      return (resp, nil)
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let date = try await client.getStudyPGNLastModified(studyId: "S")
+    XCTAssertNotNil(date)
+  }
+}
+


### PR DESCRIPTION
This PR completes the remaining Studies coverage:

- Public wrappers:
  - `deleteStudyChapter(studyId:chapterId:)` (204 -> Bool)
  - `getStudyPGNLastModified(studyId:)` (HEAD -> Date?)
- Example target: `StudiesExample`
- Tests: delete success and Last-Modified parsing
- README: added snippet under Studies

All tests pass (`swift test`).

Closes #40