### PR TITLE
feat(puzzles): activity, replay/dashboard; Storm dashboard; Racer create/get

### DIFF
--- a/Examples/PuzzlesRacerExample/main.swift
+++ b/Examples/PuzzlesRacerExample/main.swift
@@ -1,0 +1,27 @@
+import Foundation
+import LichessClient
+
+@main
+struct PuzzlesRacerExample {
+  static func main() async {
+    let client = LichessClient()
+    do {
+      // Stream your puzzle activity (NDJSON)
+      let body = try await client.getPuzzleActivity(max: 1)
+      struct Item: Decodable { let win: Bool? }
+      for try await it in Streaming.ndjsonStream(from: body, as: Item.self) { print(it.win ?? false); break }
+
+      // Puzzle replay summary for 30 days in theme "fork"
+      let replay = try await client.getPuzzleReplay(days: 30, theme: "fork")
+      print(replay?.remaining.count ?? 0)
+
+      // Create a racer and fetch its results
+      let racer = try await client.createRacer()
+      let results = try await client.getRacer(id: racer.id)
+      print(racer.id, results?.players.count ?? 0)
+    } catch {
+      print("PuzzlesRacerExample error: \(error)")
+    }
+  }
+}
+

--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,11 @@ let package = Package(
             path: "Examples/PuzzlesExample"
         ),
         .executableTarget(
+            name: "PuzzlesRacerExample",
+            dependencies: ["LichessClient"],
+            path: "Examples/PuzzlesRacerExample"
+        ),
+        .executableTarget(
             name: "TVStreamExample",
             dependencies: ["LichessClient"],
             path: "Examples/TVStreamExample"

--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ print(p.game.perf.name, p.puzzle.rating)
 // Next puzzle (optionally filter by theme)
 let next = try await client.getNextPuzzle(angle: "mateIn2")
 print(next.puzzle.id)
+
+// Your puzzle activity (NDJSON stream)
+let act = try await client.getPuzzleActivity(max: 10)
+for try await _ in act { break }
+
+// Puzzle replay summary (30 days, theme "fork")
+let replay = try await client.getPuzzleReplay(days: 30, theme: "fork")
+print(replay?.remaining.count ?? 0)
 ```
 
 ## Game Export / Import

--- a/Sources/LichessClient/LichessClient+Puzzles.swift
+++ b/Sources/LichessClient/LichessClient+Puzzles.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import OpenAPIRuntime
 
 extension LichessClient {
   public struct PuzzleGamePerf: Codable {
@@ -108,6 +109,112 @@ extension LichessClient {
       return convert(payload)
     case .undocumented(let statusCode, _):
       throw LichessClientError.undocumentedResponse(statusCode: statusCode)
+    }
+  }
+
+  // MARK: - Activity (NDJSON)
+  public func getPuzzleActivity(max: Int? = nil, before: Int? = nil) async throws -> HTTPBody {
+    let resp = try await underlyingClient.apiPuzzleActivity(
+      query: .init(max: max, before: before),
+      headers: .init(accept: [.init(contentType: .application_x_hyphen_ndjson)])
+    )
+    switch resp { case .ok(let ok): return try ok.body.application_x_hyphen_ndjson; case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  // MARK: - Replay & Dashboard
+  public struct PuzzleReplaySummary: Codable {
+    public let days: Double
+    public let theme: String
+    public let total: Double
+    public let remaining: [String]
+    public let angleKey: String
+    public let angleName: String
+    public let angleDescription: String
+  }
+
+  public func getPuzzleReplay(days: Double, theme: String) async throws -> PuzzleReplaySummary? {
+    let resp = try await underlyingClient.apiPuzzleReplay(path: .init(days: days, theme: theme))
+    switch resp {
+    case .ok(let ok):
+      let j = try ok.body.json
+      return PuzzleReplaySummary(
+        days: j.replay.days,
+        theme: j.replay.theme,
+        total: j.replay.nb,
+        remaining: j.replay.remaining,
+        angleKey: j.angle.key,
+        angleName: j.angle.name,
+        angleDescription: j.angle.desc
+      )
+    case .notFound:
+      return nil
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
+
+  public struct PuzzlePerformanceSummary: Codable { public let firstWins: Int; public let nb: Int; public let performance: Int; public let puzzleRatingAvg: Int; public let replayWins: Int }
+  public struct PuzzleDashboardSummary: Codable {
+    public let days: Int
+    public let global: PuzzlePerformanceSummary
+    public let themes: [String: PuzzlePerformanceSummary]
+  }
+
+  public func getPuzzleDashboard(days: Int) async throws -> PuzzleDashboardSummary {
+    let resp = try await underlyingClient.apiPuzzleDashboard(path: .init(days: days))
+    switch resp {
+    case .ok(let ok):
+      let j = try ok.body.json
+      func mapPerf(_ p: Components.Schemas.PuzzlePerformance) -> PuzzlePerformanceSummary {
+        .init(firstWins: p.firstWins, nb: p.nb, performance: p.performance, puzzleRatingAvg: p.puzzleRatingAvg, replayWins: p.replayWins)
+      }
+      var themes: [String: PuzzlePerformanceSummary] = [:]
+      for (k, v) in j.themes.additionalProperties { themes[k] = mapPerf(v.results) }
+      return PuzzleDashboardSummary(days: j.days, global: mapPerf(j.global), themes: themes)
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
+
+  // MARK: - Storm
+  public struct StormHighs: Codable { public let allTime: Int; public let day: Int; public let month: Int; public let week: Int }
+  public struct StormDay: Codable { public let id: String; public let combo: Int; public let errors: Int; public let highest: Int; public let moves: Int; public let runs: Int; public let score: Int; public let time: Int }
+  public struct StormDashboardSummary: Codable { public let days: [StormDay]; public let high: StormHighs }
+
+  public func getStormDashboard(username: String, lastDays: Int? = nil) async throws -> StormDashboardSummary {
+    let resp = try await underlyingClient.apiStormDashboard(path: .init(username: username), query: .init(days: lastDays))
+    switch resp {
+    case .ok(let ok):
+      let j = try ok.body.json
+      let days = j.days.map { StormDay(id: $0._id, combo: $0.combo, errors: $0.errors, highest: $0.highest, moves: $0.moves, runs: $0.runs, score: $0.score, time: $0.time) }
+      let h = j.high
+      return StormDashboardSummary(days: days, high: .init(allTime: h.allTime, day: h.day, month: h.month, week: h.week))
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
+    }
+  }
+
+  // MARK: - Racer
+  public struct PuzzleRacerInfo: Codable { public let id: String; public let url: String }
+  public struct PuzzleRacePlayer: Codable { public let name: String; public let score: Int; public let id: String?; public let flair: String?; public let patron: Bool? }
+  public struct PuzzleRaceResultsSummary: Codable { public let id: String; public let owner: String; public let players: [PuzzleRacePlayer]; public let finishesAt: Int; public let startsAt: Int }
+
+  public func createRacer() async throws -> PuzzleRacerInfo {
+    let resp = try await underlyingClient.racerPost()
+    switch resp { case .ok(let ok): let j = try ok.body.json; return .init(id: j.id, url: j.url); case .undocumented(let s, _): throw LichessClientError.undocumentedResponse(statusCode: s) }
+  }
+
+  public func getRacer(id: String) async throws -> PuzzleRaceResultsSummary? {
+    let resp = try await underlyingClient.racerGet(path: .init(id: id))
+    switch resp {
+    case .ok(let ok):
+      let j = try ok.body.json
+      let players = j.players.map { PuzzleRacePlayer(name: $0.name, score: $0.score, id: $0.id, flair: $0.flair, patron: $0.patron) }
+      return .init(id: j.id, owner: j.owner, players: players, finishesAt: j.finishesAt, startsAt: j.startsAt)
+    case .notFound:
+      return nil
+    case .undocumented(let s, _):
+      throw LichessClientError.undocumentedResponse(statusCode: s)
     }
   }
 }

--- a/Tests/LichessClientTests/PuzzlesRacerTests.swift
+++ b/Tests/LichessClientTests/PuzzlesRacerTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import LichessClient
+import OpenAPIRuntime
+import HTTPTypes
+
+final class PuzzlesRacerTests: XCTestCase {
+  struct Transport: ClientTransport {
+    let handler: @Sendable (HTTPRequest, HTTPBody?, URL, String) async throws -> (HTTPResponse, HTTPBody?)
+    func send(_ request: HTTPRequest, body: HTTPBody?, baseURL: URL, operationID: String) async throws -> (HTTPResponse, HTTPBody?) { try await handler(request, body, baseURL, operationID) }
+  }
+
+  func testPuzzleActivityNDJSONAccept() async throws {
+    var seenAccept: String?
+    let transport = Transport { req, _, _, op in
+      XCTAssertEqual(op, "apiPuzzleActivity")
+      seenAccept = req.headerFields[.accept]
+      return (HTTPResponse(status: .ok), HTTPBody("{}\n"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    _ = try await client.getPuzzleActivity(max: 10)
+    XCTAssertTrue(seenAccept?.contains("application/x-ndjson") ?? false)
+  }
+
+  func testPuzzleReplayMapsFields() async throws {
+    let json = """
+    {"replay":{"days":30,"theme":"fork","nb":12,"remaining":["abc","def"]},"angle":{"key":"tactics","name":"Tactics","desc":"desc"}}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiPuzzleReplay")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let rep = try await client.getPuzzleReplay(days: 30, theme: "fork")
+    XCTAssertEqual(rep?.theme, "fork")
+    XCTAssertEqual(rep?.remaining.count, 2)
+    XCTAssertEqual(rep?.angleKey, "tactics")
+  }
+
+  func testPuzzleDashboardMapsGlobal() async throws {
+    let json = """
+    {"days":30,"global":{"firstWins":1,"nb":2,"performance":3,"puzzleRatingAvg":4,"replayWins":5},"themes":{"fork":{"results":{"firstWins":6,"nb":7,"performance":8,"puzzleRatingAvg":9,"replayWins":10},"theme":"fork"}}}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiPuzzleDashboard")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let dash = try await client.getPuzzleDashboard(days: 30)
+    XCTAssertEqual(dash.days, 30)
+    XCTAssertEqual(dash.global.nb, 2)
+    XCTAssertNotNil(dash.themes["fork"])
+  }
+
+  func testStormDashboardMaps() async throws {
+    let json = """
+    {"days":[{"_id":"d1","combo":1,"errors":0,"highest":2,"moves":3,"runs":4,"score":5,"time":60}],"high":{"allTime":42,"day":10,"month":20,"week":15}}
+    """
+    let transport = Transport { _, _, _, op in
+      XCTAssertEqual(op, "apiStormDashboard")
+      return (HTTPResponse(status: .ok), HTTPBody(json))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let s = try await client.getStormDashboard(username: "user")
+    XCTAssertEqual(s.days.first?.score, 5)
+    XCTAssertEqual(s.high.allTime, 42)
+  }
+
+  func testRacerCreateAndGet() async throws {
+    var step = 0
+    let transport = Transport { req, _, _, op in
+      if op == "racerPost" { step = 1; return (HTTPResponse(status: .ok), HTTPBody("{\"id\":\"rid\",\"url\":\"https://lichess.org/racer/rid\"}")) }
+      if op == "racerGet" { XCTAssertEqual(step, 1); return (HTTPResponse(status: .ok), HTTPBody("{\"id\":\"rid\",\"owner\":\"me\",\"players\":[{\"name\":\"p\",\"score\":3}],\"puzzles\":[],\"finishesAt\":1,\"startsAt\":0}")) }
+      return (HTTPResponse(status: .notFound), HTTPBody("{\"error\":\"nf\"}"))
+    }
+    let client = LichessClient(configuration: .init(transport: transport))
+    let created = try await client.createRacer()
+    XCTAssertEqual(created.id, "rid")
+    let res = try await client.getRacer(id: created.id)
+    XCTAssertEqual(res?.owner, "me")
+  }
+}
+


### PR DESCRIPTION
This PR adds public wrappers for remaining Puzzles & Racer/Storm endpoints:

- `getPuzzleActivity(max:before:)` → NDJSON
- `getPuzzleReplay(days:theme:)` → summary model
- `getPuzzleDashboard(days:)` → summary model
- `getStormDashboard(username:lastDays:)` → summary model
- `createRacer()` + `getRacer(id:)`

Includes tests and a minimal example target.

All tests pass (`swift test`).

Closes #39